### PR TITLE
ticket 4183 REVISED

### DIFF
--- a/api/reviewer_api/resources/document.py
+++ b/api/reviewer_api/resources/document.py
@@ -95,7 +95,8 @@ class GetDocuments(Resource):
                 timeout=float(requestapitimeout)
             )
             response.raise_for_status()
-            result = documentservice().getdocuments(requestid)
+            bcgovcode = response.json()['bcgovcode']
+            result = documentservice().getdocuments(requestid,bcgovcode)
             return json.dumps(result), 200
         except KeyError as err:
             return {'status': False, 'message':err.messages}, 400

--- a/api/reviewer_api/services/documentservice.py
+++ b/api/reviewer_api/services/documentservice.py
@@ -291,13 +291,13 @@ class documentservice:
 
         return DocumentAttributes.update(newRows, oldRows)
 
-    def getdocuments(self, requestid):
+    def getdocuments(self, requestid,bcgovcode):
         divisions_data = requests.request(
                 method='GET',
-                url=requestapiurl + "/api/foiflow/divisions",
+                url=requestapiurl + "/api/foiflow/divisions/{0}".format(bcgovcode),
                 headers={'Authorization': AuthHelper.getauthtoken(), 'Content-Type': 'application/json'}
             ).json()
-        divisions = {div['divisionid']: div for div in divisions_data}
+        divisions = {div['divisionid']: div for div in divisions_data['divisions']}
 
         documents = {document['documentmasterid']: document for document in self.getdedupestatus(requestid)}
         attachments = []


### PR DESCRIPTION
Docreviewer backend now makes an api call to foi-flow endpoint with bcgovcode in request to gather all divisions associated with records (for a document). Previous api call from Docreviewer  to foi-flow gathered all divisions, which was not efficient. This PR/change still makes foi-flow the single source of truth for divisions and programareas.

See LINKED PR in foi-flow- https://github.com/bcgov/foi-flow/pull/4421