### PR TITLE
#4701 fix for DOCX conversion out of memory issue

### DIFF
--- a/MCS.FOI.S3FileConversion/MCS.FOI.DocToPDF/DocFileProcessor.cs
+++ b/MCS.FOI.S3FileConversion/MCS.FOI.DocToPDF/DocFileProcessor.cs
@@ -46,16 +46,38 @@ namespace MCS.FOI.DocToPDF
                             wordDocument.RevisionOptions.CommentDisplayMode = CommentDisplayMode.ShowInBalloons;
                             wordDocument.RevisionOptions.CommentColor = RevisionColor.Blue;
 
-                            //Creates an instance of DocIORenderer.
-                            using (DocIORenderer renderer = new DocIORenderer())
+                            foreach(var entity in wordDocument.ChildEntities)
                             {
-                                using PdfDocument pdfDocument = renderer.ConvertToPDF(wordDocument);
-                                //Save the PDF file
-                                //Close the instance of document objects
-                                pdfDocument.Save(output);
-                                pdfDocument.Close(true);
-                                converted = true;
+                               if(entity.GetType().FullName == "Syncfusion.DocIO.DLS.WSection")
+                               {
+                                    Syncfusion.DocIO.DLS.WSection _wsection = (Syncfusion.DocIO.DLS.WSection)entity;
+                                    
+                                    foreach (IWTable table in _wsection.Tables)
+                                    {                                       
+                                        table.TableFormat.IsAutoResized = false;                                        
+                                        table.TableFormat.WrapTextAround = true;
+                                    }
 
+                                }
+
+                            }
+
+                            using (Stream wordstream = new MemoryStream())
+                            {
+                                wordDocument.Save(wordstream, wordDocument.ActualFormatType);
+
+                                //Creates an instance of DocIORenderer.
+                                using (DocIORenderer renderer = new DocIORenderer())
+                                {
+
+                                    using PdfDocument pdfDocument = renderer.ConvertToPDF(wordstream);
+                                    //Save the PDF file
+                                    //Close the instance of document objects
+                                    pdfDocument.Save(output);
+                                    pdfDocument.Close(true);
+                                    converted = true;
+
+                                }
                             }
                         }
                     }

--- a/MCS.FOI.S3FileConversion/MCS.FOI.S3FileConversion/S3Handler.cs
+++ b/MCS.FOI.S3FileConversion/MCS.FOI.S3FileConversion/S3Handler.cs
@@ -161,7 +161,7 @@ namespace MCS.FOI.S3FileConversion
             catch (Exception exception)
             {
                 Console.WriteLine($"Error encountered on server. Message:'{exception.Message}' getting list of objects.");
-                throw exception;
+                throw;
             }
             finally
             {


### PR DESCRIPTION
There was issue with Syncfusion DOCXtoPDF conversion function for certain DOCX file that has `TABLES` objects in it with auto-resizing ON. So I am programmatically disabling it using Synfusion API . In the mean time, I am creating a ticket with Syncfusion to see whether any actual fix will be available from their side.