### PR TITLE
fix logic for starting off regex from

### DIFF
--- a/MCS.FOI.S3FileConversion/MCS.FOI.MSGToPDF/MSGFileProcessor.cs
+++ b/MCS.FOI.S3FileConversion/MCS.FOI.MSGToPDF/MSGFileProcessor.cs
@@ -140,9 +140,9 @@ namespace MCS.FOI.MSGToPDF
                                         inlineAttachments.Add(_attachment);
                                     }
                                 }
+                                var startAt = 0;
                                 foreach (var inlineAttachment in inlineAttachments.OrderBy(m => m.GetType().GetProperty("RenderingPosition").GetValue(m, null)))
                                 {
-                                    var startAt = 0;
                                     if (rtfInline)
                                     {
                                         if (!inlineAttachment.GetType().FullName.ToLower().Contains("message"))
@@ -173,7 +173,7 @@ namespace MCS.FOI.MSGToPDF
                                     else if (htmlInline)
                                     {
                                         var _inlineAttachment = (Storage.Attachment)inlineAttachment;
-                                        Regex regex = new Regex("<img((?!>).)*cid:" + _inlineAttachment.ContentId + ".*?>");
+                                        Regex regex = new Regex("<img(.|\\n)*cid:" + _inlineAttachment.ContentId + "(.|\\n)*?>");
                                         Match match = regex.Match(bodyreplaced, startAt);
                                         bodyreplaced = regex.Replace(bodyreplaced, "<img style=\"max-width: 700px\" src=\"data:" + _inlineAttachment.MimeType + ";base64," + Convert.ToBase64String(_inlineAttachment.Data) + "\"/>", 1, startAt);
                                         startAt = match.Index + match.Length;


### PR DESCRIPTION
the previous match for inline attachments