### PR TITLE
Ticket 2882. SinglePackage/1 Division Redline Package Creation Bug Fix. 

### DIFF
--- a/web/src/components/FOI/Home/Redlining.js
+++ b/web/src/components/FOI/Home/Redlining.js
@@ -3050,10 +3050,8 @@ const Redlining = React.forwardRef(
         ) {
           
           requestStitchObject[redlineStitchDivisionDetails.division] = stichedfilesForRedline;
-          setPdftronDocObjectsForRedline([]);
-          setstichedfilesForRedline(null)
         } else {
-          if (Object.keys(incompatableList)?.length > 0 && incompatableList[redlineStitchDivisionDetails.division]["incompatibleFiles"].length > 0) {
+          if (stichedfilesForRedline === null && Object.keys(incompatableList)?.length > 0 && incompatableList[redlineStitchDivisionDetails.division]["incompatibleFiles"].length > 0) {
               requestStitchObject[redlineStitchDivisionDetails.division] = null
           }
         }


### PR DESCRIPTION
Adjusted useEffect related to singlepackage/1 division redline creation logic. This fixed a bug where redline package pdfs will be corrupted for multi division ministry packages (ie. WLR, EDU etc) that have only 1 division with records that contain any amount of incompatible files



