### PR TITLE
Ticket 2995. Optimization to /redactionLayer db query + Adj to FE API calls to /redactionlayer end point

### DIFF
--- a/api/reviewer_api/models/RedactionLayers.py
+++ b/api/reviewer_api/models/RedactionLayers.py
@@ -22,18 +22,11 @@ class RedactionLayer(db.Model):
     @classmethod
     def getall(cls, ministryrequestid):
         try:
-            sql = """select rl.*, case when sq.count is null then 0 else sq.count end as count 
-                        from public."RedactionLayers" rl left join (
-                            select redactionlayerid as rlid, count(redactionlayerid) 
-                            from public."Annotations" a
-                            join public."Documents" d on d.documentid = a.documentid and d.foiministryrequestid = :ministryrequestid
-                            join public."DocumentMaster" dm on dm.documentmasterid = d.documentmasterid and dm.ministryrequestid = :ministryrequestid
-							left join public."DocumentDeleted" dd on dm.filepath ilike dd.filepath || '%' and dd.ministryrequestid = :ministryrequestid
-                            where foiministryrequestid = :ministryrequestid and a.isactive = true
-							and (dd.deleted is false or dd.deleted is null)
-                            group by redactionlayerid
-                        ) as sq on sq.rlid = rl.redactionlayerid
-                    """
+            sql = """select r.redactionlayerid, r."name", r.description, r.sortorder, count(as2.id) as count
+            from  "RedactionLayers" r left join "AnnotationSections" as2 on  r.redactionlayerid = as2.redactionlayerid and as2.foiministryrequestid = :ministryrequestid and as2.isactive = true 
+            where  r.isactive = true
+            group by  r.redactionlayerid, as2.redactionlayerid
+            """
             rs = db.session.execute(text(sql), {"ministryrequestid": ministryrequestid})
             return [
                 {

--- a/api/reviewer_api/models/RedactionLayers.py
+++ b/api/reviewer_api/models/RedactionLayers.py
@@ -22,9 +22,9 @@ class RedactionLayer(db.Model):
     @classmethod
     def getall(cls, ministryrequestid):
         try:
-            sql = """select r.redactionlayerid, r."name", r.description, r.sortorder, count(as2.id) as count
-            from  "RedactionLayers" r left join "AnnotationSections" as2 on  r.redactionlayerid = as2.redactionlayerid and as2.foiministryrequestid = :ministryrequestid and as2.isactive = true 
-            where  r.isactive = true
+            sql = """select r.redactionlayerid, r."name", r.description, r.sortorder, count(as2.id) as count 
+            from  "RedactionLayers" r left join "DocumentPageflags" as2 on  r.redactionlayerid = as2.redactionlayerid and as2.foiministryrequestid = :ministryrequestid 
+            where  r.isactive = true 
             group by  r.redactionlayerid, as2.redactionlayerid
             """
             rs = db.session.execute(text(sql), {"ministryrequestid": ministryrequestid})

--- a/api/reviewer_api/resources/redaction.py
+++ b/api/reviewer_api/resources/redaction.py
@@ -29,6 +29,7 @@ from reviewer_api.exceptions import BusinessException
 import json
 import os
 from reviewer_api.services.radactionservice import redactionservice
+from reviewer_api.services.redactionlayerservice import redactionlayerservice
 
 from reviewer_api.services.annotationservice import annotationservice
 from reviewer_api.schemas.annotationrequest import (
@@ -90,14 +91,11 @@ class AnnotationPagination(Resource):
     @auth.ismemberofgroups(getrequiredmemberships())
     def get(ministryrequestid, redactionlayer="redline", page=1, size=1000):
         try:
-            isvalid, _redactionlayer = redactionservice().validateredactionlayer(
-                redactionlayer, ministryrequestid
+            redactionlayer = redactionlayerservice().getredactionlayerobj(redactionlayer)
+            result = redactionservice().getannotationsbyrequest(
+                ministryrequestid, redactionlayer, page, size
             )
-            if isvalid == True:
-                result = redactionservice().getannotationsbyrequest(
-                    ministryrequestid, _redactionlayer, page, size
-                )
-                return result, 200
+            return result, 200
         except KeyError as error:
             return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:

--- a/api/reviewer_api/resources/redaction.py
+++ b/api/reviewer_api/resources/redaction.py
@@ -91,11 +91,13 @@ class AnnotationPagination(Resource):
     @auth.ismemberofgroups(getrequiredmemberships())
     def get(ministryrequestid, redactionlayer="redline", page=1, size=1000):
         try:
-            redactionlayer = redactionlayerservice().getredactionlayerobj(redactionlayer)
-            result = redactionservice().getannotationsbyrequest(
-                ministryrequestid, redactionlayer, page, size
-            )
-            return result, 200
+            redactionlayer = redactionlayerservice().getredactionlayer(redactionlayer)
+            if redactionlayer is not None:
+                result = redactionservice().getannotationsbyrequest(
+                    ministryrequestid, redactionlayer, page, size
+                )
+                return result, 200
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + "Invalid Layer"}, 400
         except KeyError as error:
             return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:

--- a/api/reviewer_api/services/redactionlayerservice.py
+++ b/api/reviewer_api/services/redactionlayerservice.py
@@ -23,9 +23,9 @@ class redactionlayerservice:
                 return layer["redactionlayerid"]
         return 0
     
-    def getredactionlayerobj(self, name):
+    def getredactionlayer(self, name):
         _name = self.__normalise(name)
-        layers = RedactionLayer.getlayers()
+        layers = self.getall()
         for layer in layers:
             if (self.__normalise(layer['name']) == _name):
                 return layer

--- a/api/reviewer_api/services/redactionlayerservice.py
+++ b/api/reviewer_api/services/redactionlayerservice.py
@@ -23,7 +23,14 @@ class redactionlayerservice:
                 return layer["redactionlayerid"]
         return 0
     
-
+    def getredactionlayerobj(self, name):
+        _name = self.__normalise(name)
+        layers = RedactionLayer.getlayers()
+        for layer in layers:
+            if (self.__normalise(layer['name']) == _name):
+                return layer
+        return 0
+    
     def getmappedredactionlayers(self, redactionlayer):     
         mpxlayers = []  
         mpxlayers.append(redactionlayer["redactionlayerid"])

--- a/web/src/apiManager/httpRequestHandler/index.tsx
+++ b/web/src/apiManager/httpRequestHandler/index.tsx
@@ -5,6 +5,7 @@ import { params } from "./types";
 export const httpGETRequest = (url: string, data: any, token: any, isBearer = true) => {
   return axios.get(url, {
     params: data,
+    timeout: 60000,
     headers: {
       'Access-Control-Allow-Origin' : '*',
       Authorization: isBearer

--- a/web/src/components/FOI/Home/Home.js
+++ b/web/src/components/FOI/Home/Home.js
@@ -25,7 +25,6 @@ import IconButton from "@mui/material/IconButton";
 function Home() {
   const user = useAppSelector((state) => state.user.userDetail);
   const validoipcreviewlayer = useAppSelector((state) => state.documents?.requestinfo?.validoipcreviewlayer);
-  const redactionLayers = useAppSelector((state) => state.documents?.redactionLayers);
   const [files, setFiles] = useState([]);
   // added incompatibleFiles to capture incompatible files for download redline
   const [incompatibleFiles, setIncompatibleFiles] = useState([]);
@@ -123,23 +122,19 @@ function Home() {
   }, []);
 
   useEffect(() => {
-    fetchRedactionLayerMasterData(
-      foiministryrequestid,
-      (data) => {
-        let redline = data.find((l) => l.name === "Redline");
-        let currentLayer = redline;
-        store.dispatch(setCurrentLayer(currentLayer));
-      },
-      (error) => console.log(error)
-    );
-  }, [])
-
-  useEffect(() => {
-    const oipcLayer = redactionLayers.find((layer) => layer.name === "OIPC")
-    if (validoipcreviewlayer && oipcLayer?.count > 0) {
-      store.dispatch(setCurrentLayer(oipcLayer));
+    if(validoipcreviewlayer === undefined) {
+      fetchRedactionLayerMasterData(
+        foiministryrequestid,
+        (data) => {
+          let redline = data.find((l) => l.name === "Redline");
+          let oipc = data.find((l) => l.name === "OIPC");
+          let currentLayer = validoipcreviewlayer && oipc.count > 0 ? oipc : redline;
+          store.dispatch(setCurrentLayer(currentLayer));
+        },
+        (error) => console.log(error)
+      );
     }
-  }, [validoipcreviewlayer, redactionLayers])
+  }, [validoipcreviewlayer])
 
   const prepareMapperObj = (doclistwithSortOrder) => {
     let mappedDocs = { stitchedPageLookup: {}, docIdLookup: {}, redlineDocIdLookup: {} };

--- a/web/src/components/FOI/Home/Home.js
+++ b/web/src/components/FOI/Home/Home.js
@@ -25,6 +25,7 @@ import IconButton from "@mui/material/IconButton";
 function Home() {
   const user = useAppSelector((state) => state.user.userDetail);
   const validoipcreviewlayer = useAppSelector((state) => state.documents?.requestinfo?.validoipcreviewlayer);
+  const redactionLayers = useAppSelector((state) => state.documents?.redactionLayers);
   const [files, setFiles] = useState([]);
   // added incompatibleFiles to capture incompatible files for download redline
   const [incompatibleFiles, setIncompatibleFiles] = useState([]);
@@ -126,13 +127,19 @@ function Home() {
       foiministryrequestid,
       (data) => {
         let redline = data.find((l) => l.name === "Redline");
-        let oipc = data.find((l) => l.name === "OIPC");
-        let currentLayer = validoipcreviewlayer && oipc.count > 0 ? oipc : redline; 
+        let currentLayer = redline;
         store.dispatch(setCurrentLayer(currentLayer));
       },
       (error) => console.log(error)
     );
-  }, [validoipcreviewlayer])
+  }, [])
+
+  useEffect(() => {
+    const oipcLayer = redactionLayers.find((layer) => layer.name === "OIPC")
+    if (validoipcreviewlayer && oipcLayer?.count > 0) {
+      store.dispatch(setCurrentLayer(oipcLayer));
+    }
+  }, [validoipcreviewlayer, redactionLayers])
 
   const prepareMapperObj = (doclistwithSortOrder) => {
     let mappedDocs = { stitchedPageLookup: {}, docIdLookup: {}, redlineDocIdLookup: {} };


### PR DESCRIPTION
/redactionlayer endpoint query was taking 6-10 seconds on PROD DB, this query has been revised and it takes less than a second now in PROD DB. Additionally, this api endpoint was being called more than once in a useEffect -> useeffect has been adjusted so this api endpoint is called only once (on load) in the FE.