### PR TITLE
[FOIMOD-3165] 2 Attachments With Identical Names Attached to An Email Cause an Upload Error

### DIFF
--- a/MCS.FOI.S3FileConversion/MCS.FOI.MSGToPDF/MSGFileProcessor.cs
+++ b/MCS.FOI.S3FileConversion/MCS.FOI.MSGToPDF/MSGFileProcessor.cs
@@ -56,15 +56,25 @@ namespace MCS.FOI.MSGToPDF
                                     var _attachment = (Storage.Message)attachment;
                                     var filename = _attachment.FileName;
                                     var extension = Path.GetExtension(filename);
+                                    var baseFilename = Path.GetFileNameWithoutExtension(filename);
                                     if (!string.IsNullOrEmpty(extension))
                                     {
                                         _attachment.Save(attachmentStream);
                                         Dictionary<string, string> attachmentInfo = new Dictionary<string, string>();
-
+                                        
+                                        // If the filename already exists, increment the duplicate count to create a unique filename
                                         if (fileNameHash.ContainsKey(filename))
                                         {
-
-                                            filename = Path.GetFileNameWithoutExtension(filename) + '1' + extension;
+                                            int duplicateCount = 1; // Initialize the duplicate count
+                                            string newFilename;
+                                            
+                                            // Loop until a unique filename is found
+                                            do
+                                            {
+                                                newFilename = baseFilename + duplicateCount.ToString() + extension;
+                                                duplicateCount++;
+                                            } while (fileNameHash.ContainsKey(newFilename));
+                                            filename = newFilename;
                                         }
                                         fileNameHash.Add(filename, true);
                                         attachmentInfo.Add("filename", _attachment.FileName);
@@ -80,19 +90,27 @@ namespace MCS.FOI.MSGToPDF
                                     var _attachment = (Storage.Attachment)attachment;
                                     var filename = _attachment.FileName;
                                     var extension = Path.GetExtension(filename);
-
+                                    var baseFilename = Path.GetFileNameWithoutExtension(filename);
                                     if (!string.IsNullOrEmpty(extension))
                                     {
                                         attachmentStream.Write(_attachment.Data, 0, _attachment.Data.Length);
                                         Dictionary<string, string> attachmentInfo = new Dictionary<string, string>();
-
+                                        
+                                        // If the filename already exists, increment the duplicate count to create a unique filename
                                         if (fileNameHash.ContainsKey(filename))
                                         {
-
-                                            filename = Path.GetFileNameWithoutExtension(filename) + '1' + extension;
+                                            int duplicateCount = 1;  // Initialize the duplicate count
+                                            string newFilename;
+                                            // Loop until a unique filename is found
+                                            do
+                                            {
+                                                newFilename = baseFilename + '-' +duplicateCount.ToString() + extension;
+                                                duplicateCount++;
+                                            } while (fileNameHash.ContainsKey(newFilename));
+                                            filename = newFilename; // Set the unique filename
                                         }
                                         fileNameHash.Add(filename, true);
-                                        attachmentInfo.Add("filename", _attachment.FileName);
+                                        attachmentInfo.Add("filename", filename);
                                         attachmentInfo.Add("s3filename", filename);
                                         attachmentInfo.Add("cid", _attachment.ContentId);
                                         attachmentInfo.Add("size", _attachment.Data.Length.ToString());


### PR DESCRIPTION
[FOIMOD-3165](https://citz-imb.atlassian.net/browse/FOIMOD-3165)
- Changed filenames by appending incrementing numbers to duplicates (e.g., sample-1, sample-2, and so on).

[FOIMOD-3165]: https://citz-imb.atlassian.net/browse/FOIMOD-3165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ