### PR TITLE
sort redactionlayerid by id as well as created_at because sometimes c…

### DIFF
--- a/computingservices/DocumentServices/services/dal/documentpageflag.py
+++ b/computingservices/DocumentServices/services/dal/documentpageflag.py
@@ -225,7 +225,7 @@ class documentpageflag:
                 select redactionlayerid  
                 from "DocumentPageflags" 
                 where foiministryrequestid = %s::integer
-                order by created_at desc limit 1;
+                order by created_at, id desc limit 1;
             '''
             cursor.execute(query, (ministryrequestid,))
             layerid = cursor.fetchone()


### PR DESCRIPTION
…reated_at is identical between layers