### PR TITLE
Verify and split pages if the total number of pages to be stitched exceeds the document's total page count.

### DIFF
--- a/web/src/components/FOI/Home/Redlining.js
+++ b/web/src/components/FOI/Home/Redlining.js
@@ -1499,6 +1499,10 @@ const Redlining = React.forwardRef(
           (_file) => _file.file.file.documentid === filerow.file.file.documentid
         );
         if (_exists?.length === 0) {
+          // Check if total pages to be stitched is greater than the total pages in the document
+          if(filerow.pages.length > filerow.pdftronobject.getPageCount()) {
+                filerow.pages = filerow.pages.slice(0, filerow.pdftronobject.getPageCount());
+          }
           let index = filerow.stitchIndex;
           _doc
             .insertPages(filerow.pdftronobject, filerow.pages, index)


### PR DESCRIPTION
**Description**

This PR addresses the following issue:
  - Insertion Error in Redaction App on Load

**Changes**

 - Added a check to ensure that the total pages to be stitched do not exceed the total pages in the document.
 - Sliced the `filerow.pages` array to match the total page count of the document if it exceeds the limit.