### PR TITLE
FOIMOD-3566- Observation fixes

### DIFF
--- a/web/src/components/FOI/Home/DocumentSelector.tsx
+++ b/web/src/components/FOI/Home/DocumentSelector.tsx
@@ -712,7 +712,14 @@ const DocumentSelector = React.memo(
                       .flatMap((flag: any) => "Phase "+ flag.phase) 
                 : []
           ));
-          setAssignedPhases([...phases]);
+          // Convert Set to Array and sort numerically
+          const sortedPhases = [...phases]?.sort((a: any, b: any) => {
+            const numA = parseInt(a.replace("Phase ", ""), 10);
+            const numB = parseInt(b.replace("Phase ", ""), 10);
+            return numA - numB;
+          });
+
+          setAssignedPhases(sortedPhases);
           if(phases.size >0){
             setOpenPhaseFilterModal(true);
             setAnchorElPhases(e.currentTarget);


### PR DESCRIPTION
Fixed Observation #7 - The Phase flag filter order should be sequential (Phase 1, 2, 3, 4, 5, 6, 7, 8, 9), regardless of when pages are flagged with a Phase flag, or the order in which the pages are flagged.