### PR TITLE
fix: add validation for malformed annotation timestamps in __converttoPST

### DIFF
--- a/computingservices/DedupeServices/services/s3documentservice.py
+++ b/computingservices/DedupeServices/services/s3documentservice.py
@@ -98,21 +98,6 @@ def _generate_file_attachments(producermessage, reader, auth):
                     # Placeholder logic to handle pdf attachments+embedds. Once resources available to revise feature, and extract attachments + embedds into one new parent PDF, this error handling will be removed.
                     raise Exception("PDF contains attachments and/or embedded files. File must be manually fixed and replaced")
 
-                    # Old logic to extract embedded files. Uncomment when new feature to save pdf embedds + attachemnts as one file is started.
-                    # producermessage.attributes["hasattachment"] = True
-                    # fileobj = annotation.get_object()["/FS"]
-                    # file = fileobj["/F"]
-                    # data = fileobj["/EF"]["/F"].get_data()
-                    # # data = BytesIO(data).getvalue()
-                    # s3uripath = (
-                    #     path.splitext(producermessage.s3filepath)[0]
-                    #     + "/"
-                    #     + "{0}{1}".format(uuid.uuid4(), path.splitext(file)[1])
-                    # )
-                    # uploadresponse = requests.put(s3uripath, data=data, auth=auth)
-                    # uploadresponse.raise_for_status()
-                    # attachment = _prepareattachment(producermessage, data, s3uripath, file)
-                    # file_attachments.append(attachment)
     return file_attachments
 
 # New function to split comments into pages
@@ -231,39 +216,6 @@ def _clearmetadata(response, pagecount, reader, s3_access_key_id,s3_secret_acces
         )
         uploadresponse.raise_for_status()
     return pagecount
-
-
-# def __flattenfitz1(docbytesarr):
-#     doc = fitz.open(stream=BytesIO(docbytesarr))
-#     out = fitz.open()  # output PDF
-#     for page_num in range(len(doc)):
-#         page = doc[page_num]
-#         w, h = page.rect.br  # page width and height
-#         # Create a new page in the output document with the same size
-#         outpage = out.new_page(width=w, height=h)
-#         # Render the page text (keeping it searchable)
-#         outpage.show_pdf_page(page.rect, doc, page_num)
-#         # Manually process each annotation
-#         annot = page.first_annot
-#         while annot:
-#             try:
-#                 annot_rect = annot.rect  # Get the annotation's rectangle
-#                 # Check for invalid annotation dimensions (zero width/height)
-#                 if annot_rect.width <= 0 or annot_rect.height <= 0:
-#                     print(f"Skipping annotation on page {page_num + 1}: Invalid annotation dimensions.")
-#                     annot = annot.next  # Move to the next annotation
-#                     continue  # Skip invalid annotation
-#                 # Render the annotation area as an image and burn it into the page
-#                 annot_pix = page.get_pixmap(clip=annot_rect, dpi=150)  # Render annotation as pixmap
-#                 outpage.insert_image(annot_rect, pixmap=annot_pix)  # Burn annotation into the page
-#             except Exception as e:
-#                 print(f"Error processing annotation on page {page_num + 1}: {e}")
-#             annot = annot.next  # Move to the next annotation
-#     # Saving the flattened PDF to a buffer
-#     buffer = BytesIO()
-#     out.save(buffer, garbage=3, deflate=True)
-#     buffer.seek(0)  # Reset the buffer to the beginning
-#     return buffer
 
 
 def __flattenfitz(docbytesarr):
@@ -602,16 +554,25 @@ def get_dimension_value(value):
     return float(value) if isinstance(value, (Decimal, float)) else value
 
 def __converttoPST(creationdate):
-    original_timestamp = creationdate
-    # Extract date and time components from the timestamp
-    timestamp_str = original_timestamp[2:]  # Remove the leading "D:"
-    timestamp_str = timestamp_str.replace("'", ":")    
-    if timestamp_str.endswith(":"):
-        timestamp_str = timestamp_str[:-1]   
-    # Parse the timestamp into a datetime object
-    timestamp_utc = maya.parse(timestamp_str).datetime(to_timezone='America/Vancouver', naive=False) 
-    formatted_utc = timestamp_utc.strftime("%Y/%m/%d %I:%M:%S %p")  # Adjust format for output
-    return formatted_utc + " PST"
+    try:
+        if not creationdate or not creationdate.startswith("D:"):
+            return "Unknown PST"
+
+        timestamp_str = creationdate[2:].replace("'", ":")
+        if timestamp_str.endswith(":"):
+            timestamp_str = timestamp_str[:-1]
+
+        # Basic year sanity check
+        year = int(timestamp_str[:4])
+        if year < 1900:
+            return "Unknown PST"
+
+        timestamp_utc = maya.parse(timestamp_str).datetime(to_timezone='America/Vancouver', naive=False)
+        return timestamp_utc.strftime("%Y/%m/%d %I:%M:%S %p") + " PST"
+    
+    except Exception as e:
+        print(f"[__converttoPST] Failed to parse date '{creationdate}': {e}")
+        return "Unknown PST"
 
 
 

--- a/computingservices/DedupeServices/services/s3documentservice.py
+++ b/computingservices/DedupeServices/services/s3documentservice.py
@@ -98,6 +98,21 @@ def _generate_file_attachments(producermessage, reader, auth):
                     # Placeholder logic to handle pdf attachments+embedds. Once resources available to revise feature, and extract attachments + embedds into one new parent PDF, this error handling will be removed.
                     raise Exception("PDF contains attachments and/or embedded files. File must be manually fixed and replaced")
 
+                    # Old logic to extract embedded files. Uncomment when new feature to save pdf embedds + attachemnts as one file is started.
+                    # producermessage.attributes["hasattachment"] = True
+                    # fileobj = annotation.get_object()["/FS"]
+                    # file = fileobj["/F"]
+                    # data = fileobj["/EF"]["/F"].get_data()
+                    # # data = BytesIO(data).getvalue()
+                    # s3uripath = (
+                    #     path.splitext(producermessage.s3filepath)[0]
+                    #     + "/"
+                    #     + "{0}{1}".format(uuid.uuid4(), path.splitext(file)[1])
+                    # )
+                    # uploadresponse = requests.put(s3uripath, data=data, auth=auth)
+                    # uploadresponse.raise_for_status()
+                    # attachment = _prepareattachment(producermessage, data, s3uripath, file)
+                    # file_attachments.append(attachment)
     return file_attachments
 
 # New function to split comments into pages


### PR DESCRIPTION
This PR fixes a runtime error in the `__converttoPST` function where malformed or missing `/CreationDate` values in PDF annotations could cause `maya.parse` to throw an exception (e.g., `ValueError: year 0 is out of range`).
