### PR TITLE
Ticket 3872: Bug fix to flatten logic in Dedupe services

### DIFF
--- a/computingservices/DedupeServices/services/s3documentservice.py
+++ b/computingservices/DedupeServices/services/s3documentservice.py
@@ -242,17 +242,25 @@ def __flattenfitz(docbytesarr):
         #page = doc[page_num]
         page = doc.load_page(page_num) 
         print("\nPage:",page)
-        widget_exist = page.first_widget is not None
-        w, h = page.rect.br  # page width and height
+        rotation = page.rotation
+        # print("\nRotation:",rotation)
+        # Reset rotation to 0 to ensure consistent rendering of page content
+        if rotation != 0:
+            page.set_rotation(0)
+        w = page.rect.width # page width
+        h = page.rect.height # page height
         # Create a new page in the output document with the same size
         outpage = out.new_page(width=w, height=h)
         print("\noutpage:",outpage)
         # Render the page text (keeping it searchable)
-        outpage.show_pdf_page(page.rect, doc, page_num)
+        rect = fitz.Rect(0, 0, w, h)
+        outpage.show_pdf_page(rect, doc, page_num)
+        # outpage.set_rotation(0) # set rotation of new page to 0 (letter/vertical pdf position)
         #print("\n####")
         # Manually process each annotation
         annot = page.first_annot
         print("\nannot",annot)
+        widget_exist = page.first_widget is not None
         if widget_exist:
             print("\nwidget_exist:",widget_exist)
             pix = page.get_pixmap(dpi=150)  # set desired resolution


### PR DESCRIPTION
This pull request modifies the `__flattenfitz` function in `s3documentservice.py` to improve the handling of page rotation and ensure consistent rendering of PDF page content in newly created flattened pdf. 