### PR TITLE
Ticket 4035 - Bug fix to adjust annotation loading process

### DIFF
--- a/web/src/components/FOI/Home/Home.js
+++ b/web/src/components/FOI/Home/Home.js
@@ -47,6 +47,7 @@ function Home() {
   const [pageFlags, setPageFlags]= useState([]);
   const [isBalanceFeeOverrode , setIsBalanceFeeOverrode] = useState(false);
   const [outstandingBalance, setOutstandingBalance]= useState(0);
+  const [isAnnotationsLoading, setIsAnnotationsLoading] = useState(true);
 
   const redliningRef = useRef();
   const selectorRef = useRef();
@@ -303,6 +304,7 @@ function Home() {
                   pageMappedDocs={pageMappedDocs}
                   setIsStitchingLoaded={setIsStitchingLoaded}
                   isStitchingLoaded={isStitchingLoaded}
+                  setIsAnnotationsLoading={setIsAnnotationsLoading}
                   incompatibleFiles={incompatibleFiles}
                   setWarningModalOpen={setWarningModalOpen}
                   scrollLeftPanel={scrollLeftPanel}
@@ -315,7 +317,7 @@ function Home() {
               )
             // : <div>Loading</div>
           }
-          {!isStitchingLoaded && (
+          {!isStitchingLoaded && !isAnnotationsLoading && (
             <div className="merging-overlay">
               <div>
                 <DocumentLoader />

--- a/web/src/components/FOI/Home/Home.js
+++ b/web/src/components/FOI/Home/Home.js
@@ -317,7 +317,7 @@ function Home() {
               )
             // : <div>Loading</div>
           }
-          {!isStitchingLoaded && !isAnnotationsLoading && (
+          {!isStitchingLoaded || isAnnotationsLoading && (
             <div className="merging-overlay">
               <div>
                 <DocumentLoader />

--- a/web/src/components/FOI/Home/Home.js
+++ b/web/src/components/FOI/Home/Home.js
@@ -317,7 +317,7 @@ function Home() {
               )
             // : <div>Loading</div>
           }
-          {!isStitchingLoaded || isAnnotationsLoading && (
+          {(!isStitchingLoaded || isAnnotationsLoading) && (
             <div className="merging-overlay">
               <div>
                 <DocumentLoader />

--- a/web/src/components/FOI/Home/Redlining.js
+++ b/web/src/components/FOI/Home/Redlining.js
@@ -870,6 +870,8 @@ const Redlining = React.forwardRef(
                       meta["next_num"],
                       meta["pages"]
                     );
+                  } else {
+                    setIsAnnotationsLoading(false);
                   }
                 }
               },
@@ -1691,7 +1693,8 @@ const Redlining = React.forwardRef(
         fetchPromises.push(promise);
       }
       try {
-        await Promise.all(fetchPromises)
+        await Promise.all(fetchPromises);
+        setIsAnnotationsLoading(false);
       }
       catch(err) {
         console.error("Error:", err);
@@ -1700,12 +1703,15 @@ const Redlining = React.forwardRef(
       }
     };
     
-    useEffect(() => {
-      if (!docViewer) return;
-      const handler = () => setIsAnnotationsLoading(false);
-      docViewer?.addEventListener('annotationsLoaded', handler);
-      return () => docViewer?.removeEventListener('annotationsLoaded', handler);
-    }, [docViewer]);
+    // useEffect(() => {
+    //   if (!docViewer) return;
+    //   const handler = () => {
+    //     console.log("BANG ANNOTS LOADDED")
+    //     setIsAnnotationsLoading(false);
+    //   }
+    //   docViewer?.addEventListener('annotationsLoaded', handler);
+    //   return () => docViewer?.removeEventListener('annotationsLoaded', handler);
+    // }, [docViewer]);
 
     useEffect(() => {
       if (errorMessage) {

--- a/web/src/components/FOI/Home/Redlining.js
+++ b/web/src/components/FOI/Home/Redlining.js
@@ -870,10 +870,6 @@ const Redlining = React.forwardRef(
                       meta["next_num"],
                       meta["pages"]
                     );
-                  } else {
-                    docViewer.addEventListener('annotationsLoaded', () => {
-                      setIsAnnotationsLoading(false);
-                    });
                   }
                 }
               },
@@ -1694,18 +1690,22 @@ const Redlining = React.forwardRef(
         });
         fetchPromises.push(promise);
       }
-      Promise.all(fetchPromises)
-      .then((res) => {
-        docViewer.addEventListener('annotationsLoaded', () => {
-          setIsAnnotationsLoading(false);
-        });
-      })
-      .error((err) => {
+      try {
+        await Promise.all(fetchPromises)
+      }
+      catch(err) {
         console.error("Error:", err);
         setErrorMessage("Error in fetching and applying all annotations, please refresh browser and try again");
         setIsAnnotationsLoading(false);
-      })
+      }
     };
+    
+    useEffect(() => {
+      if (!docViewer) return;
+      const handler = () => setIsAnnotationsLoading(false);
+      docViewer?.addEventListener('annotationsLoaded', handler);
+      return () => docViewer?.removeEventListener('annotationsLoaded', handler);
+    }, [docViewer]);
 
     useEffect(() => {
       if (errorMessage) {

--- a/web/src/components/FOI/Home/Redlining.js
+++ b/web/src/components/FOI/Home/Redlining.js
@@ -841,7 +841,6 @@ const Redlining = React.forwardRef(
                 if (!fetchAnnotResponse) {
                   setMerge(true);
                   setFetchAnnotResponse(data);
-                  setIsAnnotationsLoading(false);
                 } else {
                   //oipc changes - begin
                   //Set to read only if oipc layer exists
@@ -872,7 +871,9 @@ const Redlining = React.forwardRef(
                       meta["pages"]
                     );
                   } else {
-                    setIsAnnotationsLoading(false);
+                    docViewer.addEventListener('annotationsLoaded', () => {
+                      setIsAnnotationsLoading(false);
+                    });
                   }
                 }
               },
@@ -1693,16 +1694,17 @@ const Redlining = React.forwardRef(
         });
         fetchPromises.push(promise);
       }
-      try {
-        await Promise.all(fetchPromises);
-      } catch (error) {
-        console.log("Error:", error);
-        setErrorMessage(
-          "Error occurred while fetching all annotations, please refresh browser and try again"
-        );
-      } finally {
+      Promise.all(fetchPromises)
+      .then((res) => {
+        docViewer.addEventListener('annotationsLoaded', () => {
+          setIsAnnotationsLoading(false);
+        });
+      })
+      .error((err) => {
+        console.error("Error:", err);
+        setErrorMessage("Error in fetching and applying all annotations, please refresh browser and try again");
         setIsAnnotationsLoading(false);
-      }
+      })
     };
 
     useEffect(() => {


### PR DESCRIPTION
This pull request introduces a new `isAnnotationsLoading` state to improve the handling of annotation loading status in the `Home` and `Redlining` components.

### State Management Enhancements:

* Added a new `isAnnotationsLoading` state in the `Home` component to track the loading status of annotations (`web/src/components/FOI/Home/Home.js`, [web/src/components/FOI/Home/Home.jsR50](diffhunk://#diff-b04c516d0a29d6e6aed7149265827e02fc9c0ddf78bf22282459f91baf8dcf87R50)).
* Updated the conditional rendering logic in the `Home` component to account for `isAnnotationsLoading`, ensuring the loading overlay is displayed appropriately (`web/src/components/FOI/Home/Home.js`, [web/src/components/FOI/Home/Home.jsL318-R320](diffhunk://#diff-b04c516d0a29d6e6aed7149265827e02fc9c0ddf78bf22282459f91baf8dcf87L318-R320)).

### Integration with Annotation Processes:

* Passed the `setIsAnnotationsLoading` function as a prop to the `Redlining` component to allow it to control the annotation loading state (`web/src/components/FOI/Home/Home.js`, [[1]](diffhunk://#diff-b04c516d0a29d6e6aed7149265827e02fc9c0ddf78bf22282459f91baf8dcf87R307); `web/src/components/FOI/Home/Redlining.js`, [[2]](diffhunk://#diff-324850bc4cbdcaa655bd78feafe8509afaa71e2c0e21c9ee9a00c34e7f67fb37R93).
* Modified the `Redlining` component to set `isAnnotationsLoading` to `true` when initiating annotation fetching and to `false` once annotations are successfully loaded or an error occurs (`web/src/components/FOI/Home/Redlining.js`, [[1]](diffhunk://#diff-324850bc4cbdcaa655bd78feafe8509afaa71e2c0e21c9ee9a00c34e7f67fb37R834) [[2]](diffhunk://#diff-324850bc4cbdcaa655bd78feafe8509afaa71e2c0e21c9ee9a00c34e7f67fb37R873-R882) [[3]](diffhunk://#diff-324850bc4cbdcaa655bd78feafe8509afaa71e2c0e21c9ee9a00c34e7f67fb37R1672-R1707).