### PR TITLE
Ticket 4035 - Bug Fix for Annotation Loading (Part 2) 

### DIFF
--- a/web/src/components/FOI/Home/Redlining.js
+++ b/web/src/components/FOI/Home/Redlining.js
@@ -841,6 +841,7 @@ const Redlining = React.forwardRef(
                 if (!fetchAnnotResponse) {
                   setMerge(true);
                   setFetchAnnotResponse(data);
+                  setIsAnnotationsLoading(false);
                 } else {
                   //oipc changes - begin
                   //Set to read only if oipc layer exists
@@ -1702,16 +1703,6 @@ const Redlining = React.forwardRef(
         setIsAnnotationsLoading(false);
       }
     };
-    
-    // useEffect(() => {
-    //   if (!docViewer) return;
-    //   const handler = () => {
-    //     console.log("BANG ANNOTS LOADDED")
-    //     setIsAnnotationsLoading(false);
-    //   }
-    //   docViewer?.addEventListener('annotationsLoaded', handler);
-    //   return () => docViewer?.removeEventListener('annotationsLoaded', handler);
-    // }, [docViewer]);
 
     useEffect(() => {
       if (errorMessage) {


### PR DESCRIPTION
Adjusted logic to ensure page loads if only 1 chunk of annots loaded or if no annots loaded. 