### PR TITLE
Ticket 4035 - Bug Fix Part 3 

### DIFF
--- a/web/src/components/FOI/Home/Home.js
+++ b/web/src/components/FOI/Home/Home.js
@@ -48,6 +48,7 @@ function Home() {
   const [isBalanceFeeOverrode , setIsBalanceFeeOverrode] = useState(false);
   const [outstandingBalance, setOutstandingBalance]= useState(0);
   const [isAnnotationsLoading, setIsAnnotationsLoading] = useState(true);
+  const [areAnnotationsRendered, setAreAnnotationsRendered] = useState(false);
 
   const redliningRef = useRef();
   const selectorRef = useRef();
@@ -305,9 +306,11 @@ function Home() {
                   setIsStitchingLoaded={setIsStitchingLoaded}
                   isStitchingLoaded={isStitchingLoaded}
                   setIsAnnotationsLoading={setIsAnnotationsLoading}
+                  setAreAnnotationsRendered={setAreAnnotationsRendered}
                   incompatibleFiles={incompatibleFiles}
                   setWarningModalOpen={setWarningModalOpen}
                   scrollLeftPanel={scrollLeftPanel}
+                  isAnnotationsLoading={isAnnotationsLoading}
                   isBalanceFeeOverrode={isBalanceFeeOverrode}
                   outstandingBalance={outstandingBalance}
                   pageFlags={pageFlags}
@@ -317,7 +320,7 @@ function Home() {
               )
             // : <div>Loading</div>
           }
-          {(!isStitchingLoaded || isAnnotationsLoading) && (
+          {(!isStitchingLoaded || isAnnotationsLoading || !areAnnotationsRendered) && (
             <div className="merging-overlay">
               <div>
                 <DocumentLoader />

--- a/web/src/components/FOI/Home/Redlining.js
+++ b/web/src/components/FOI/Home/Redlining.js
@@ -90,7 +90,9 @@ const Redlining = React.forwardRef(
       pageFlags, 
       syncPageFlagsOnAction,
       isPhasedRelease,
+      isAnnotationsLoading,
       setIsAnnotationsLoading,
+      setAreAnnotationsRendered,
     },
     ref
   ) => {
@@ -1769,6 +1771,17 @@ const Redlining = React.forwardRef(
         });
       }
     };
+
+    //useEffect that ensures that all annotations are rendered to FE Object after all annotations are fetched from BE
+    useEffect(() => {
+      if (!docViewer || !annotManager) return;
+      setAreAnnotationsRendered(false);
+      if (!isAnnotationsLoading) {
+        docViewer.getAnnotationsLoadedPromise().then(() => {
+          setAreAnnotationsRendered(true);
+        })
+      }
+    }, [docViewer, annotManager, fetchAnnotResponse, setAreAnnotationsRendered, isAnnotationsLoading]);
 
     useEffect(() => {
       if (docsForStitcing.length > 0) {


### PR DESCRIPTION
This pull request introduces changes to improve the handling of annotation rendering in the `Home` and `Redlining` components. The most important updates include adding a new state variable to track the rendering status of annotations, updating the UI to account for this new state, and implementing a `useEffect` hook to ensure annotations are fully rendered after being fetched.