### PR TITLE
Ticket 4036: Timeout Error (Excel Conversion)

### DIFF
--- a/MCS.FOI.S3FileConversion/MCS.FOI.S3FileConversion/Program.cs
+++ b/MCS.FOI.S3FileConversion/MCS.FOI.S3FileConversion/Program.cs
@@ -197,7 +197,7 @@ namespace MCS.FOI.S3FileConversion
                                 }
                                 catch (Exception ex)
                                 {
-                                    var errorMessage = $" Error happpened while converting {message["s3filepath"]}. Exception message : {ex.Message}, StackTrace :{ex.StackTrace}";
+                                    var errorMessage = $" Error happened while converting {message["s3filepath"]}. Exception message : {ex.Message}, StackTrace :{ex.StackTrace}";
                                     Console.WriteLine(errorMessage);
                                     await dbhandler.recordJobEnd(message, true, errorMessage, new List<Dictionary<string, String>>());
                                 }
@@ -215,8 +215,8 @@ namespace MCS.FOI.S3FileConversion
             }
             catch (Exception ex)
             {
-                Console.WriteLine($" Error happpened while running the FOI File Conversion service. Exception message : {ex.Message} , StackTrace :{ex.StackTrace}");
-                Log.Information($" Error happpened while running the FOI File Conversion service. Exception message : {ex.Message} , StackTrace :{ex.StackTrace}");
+                Console.WriteLine($" Error happened while running the FOI File Conversion service. Exception message : {ex.Message} , StackTrace :{ex.StackTrace}");
+                Log.Information($" Error happened while running the FOI File Conversion service. Exception message : {ex.Message} , StackTrace :{ex.StackTrace}");
             }
             finally
             {

--- a/MCS.FOI.S3FileConversion/MCS.FOI.S3FileConversion/S3Handler.cs
+++ b/MCS.FOI.S3FileConversion/MCS.FOI.S3FileConversion/S3Handler.cs
@@ -69,7 +69,7 @@ namespace MCS.FOI.S3FileConversion
                        
                         using HttpResponseMessage response = await client.GetAsync(presignedGetURL);
                         response.EnsureSuccessStatusCode();
-                        using Stream responseStream = response.Content.ReadAsStream();
+                        using Stream responseStream = await response.Content.ReadAsStreamAsync();
 
                         // Convert File
                         string extension = Path.GetExtension(fileKey).ToLower();


### PR DESCRIPTION
This pull request introduces error handling improvements, timeout management, and minor corrections to the codebase for better reliability and clarity. Key changes include implementing a timeout mechanism for opening Excel files, correcting typos in error messages, and ensuring asynchronous handling of HTTP response streams.

### Error handling improvements:

* [`MCS.FOI.S3FileConversion/MCS.FOI.ExcelToPDF/ExcelFileProcessor.cs`](diffhunk://#diff-ddd70fe6ec0e5e3beb420702ac64146b3216c37873519b8b311bb73228d42654L67-R83): Added a timeout mechanism to handle cases where opening an Excel file exceeds 120 seconds. This ensures jobs are dropped if they take too long, allowing other conversion jobs to proceed.

### Minor corrections:

* [`MCS.FOI.S3FileConversion/MCS.FOI.S3FileConversion/Program.cs`](diffhunk://#diff-271c7f435441bc760405cbc4f65747d2e786ffced816e032c278060d1352144bL200-R200): Fixed typos in error messages for better clarity in logging and console output. [[1]](diffhunk://#diff-271c7f435441bc760405cbc4f65747d2e786ffced816e032c278060d1352144bL200-R200) [[2]](diffhunk://#diff-271c7f435441bc760405cbc4f65747d2e786ffced816e032c278060d1352144bL218-R219)

### Asynchronous handling:

* [`MCS.FOI.S3FileConversion/MCS.FOI.S3FileConversion/S3Handler.cs`](diffhunk://#diff-16b1a3e6a36d50eba18b2ad11a7a733e0400300eab037591cfbe7ba430b04e09L72-R72): Updated the code to use `ReadAsStreamAsync` for handling HTTP response streams asynchronously, improving performance and reliability.