### PR TITLE
Fix for batch upload notification

### DIFF
--- a/computingservices/CompressionServices/foirediscompressionconsumer.go
+++ b/computingservices/CompressionServices/foirediscompressionconsumer.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"compressionservices/models"
-	"compressionservices/rstreamio"
 	"compressionservices/services"
 	"compressionservices/utils"
 
@@ -100,13 +99,13 @@ func processStreamMessage(rdb *redis.Client, lastIDKey string, msg redis.XMessag
 	if hasError {
 		fmt.Printf("Batch not yet complete")
 	}
-	//fmt.Printf("Batch completed:%v\n", complete)
+	fmt.Printf("Batch completed:%v\n", complete)
 	//Placeholder for notification logic
-	if complete {
-		rstreamio.SendNotification(producerMessage, hasError)
-	} else {
-		fmt.Printf("Batch not yet complete, no message sent")
-	}
+	// if complete {
+	// 	rstreamio.SendNotification(producerMessage, hasError)
+	// } else {
+	// 	fmt.Printf("Batch not yet complete, no message sent")
+	// }
 	// Update last processed ID
 	if err := rdb.Set(ctx, lastIDKey, msg.ID, 0).Err(); err != nil {
 		return fmt.Errorf("error saving last ID to Redis: %w", err)

--- a/computingservices/DedupeServices/services/dedupedbservice.py
+++ b/computingservices/DedupeServices/services/dedupedbservice.py
@@ -156,25 +156,8 @@ def isbatchcompleted(batch):
             (batch,)
         )
         (dedupeinprogress, dedupeerr, _dedupecompleted) = cursor.fetchone()
-        if dedupeinprogress > 0:
-            cursor.close()
-            conn.close()
-            return False, dedupeerr > 0
-        cursor.execute('''select count(1) filter (where status = 'pushedtostream' or status = 'started') as inprogress,
-            count(1) filter (where status = 'error') as error,
-            count(1) filter (where status = 'completed') as completed
-            from (select max(version) as version,  compressionjobid
-            from public."CompressionJob"
-            where batch = %s
-            group by compressionjobid) sq
-            join public."CompressionJob" dj
-                on dj.compressionjobid = sq.compressionjobid
-                and dj.version = sq.version;''',
-            (batch,)
-        )
-        (compressioninprogress, compressionerr, _compressioncompleted) = cursor.fetchone()
         cursor.close()
-        return dedupeinprogress == 0 and conversioninprogress == 0 and compressioninprogress == 0, dedupeerr+conversionerr+compressionerr > 0
+        return dedupeinprogress == 0 and conversioninprogress == 0, dedupeerr+conversionerr > 0
     except(Exception) as error:
         print("Exception while executing func isbatchcompleted (p2), Error : {0} ".format(error))
         raise

--- a/computingservices/DedupeServices/services/foiredisdedupeconsumer.py
+++ b/computingservices/DedupeServices/services/foiredisdedupeconsumer.py
@@ -48,19 +48,18 @@ def start(consumer_id: str, start_from: StartFrom = StartFrom.latest):
         messages = stream.read(last_id=last_id, block=BLOCK_TIME)
         if messages:
             for message_id, message in messages:
-                print(f"processing {message_id}::{message}")
+                #print(f"processing {message_id}::{message}")
                 if message is not None:
                     _message = json.dumps({key.decode('utf-8'): value.decode('utf-8') for (key, value) in message.items()})
                     try:
                         producermessage = jsonmessageparser.getdedupeproducermessage(_message)
                         processmessage(producermessage) 
-
                         # send message to notification stream if batch is complete
                         complete, err = isbatchcompleted(producermessage.batch)
-                        # if complete:
-                        #     redisstreamwriter().sendnotification(producermessage, err)
-                        # else:
-                        #     print("batch not yet complete, no message sent")
+                        if complete:
+                            redisstreamwriter().sendnotification(producermessage, err)
+                        else:
+                            print("batch not yet complete, no message sent")
                     except(Exception) as error:
                         print("Exception while processing redis message, func start(p1), Error : {0} ".format(error))
                                              


### PR DESCRIPTION
Multiple notifications sending when batch upload happens: So removed the Notification sending logic from compression and kept the old logic for notification to be send once Dedupe finishes.