### PR TITLE
upgrade python base image

### DIFF
--- a/computingservices/DocumentServices/DockerFile.bcgov
+++ b/computingservices/DocumentServices/DockerFile.bcgov
@@ -1,4 +1,4 @@
-FROM artifacts.developer.gov.bc.ca/docker-remote/python:3.10.8-buster
+FROM artifacts.developer.gov.bc.ca/docker-remote/python:3.10.18-bullseye
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Upgrading python image to Bullseye as buster uses Debian 10 which is now depreciated and no longer has files it need to build the image.