### PR TITLE
speed up annotations fetch with anti-join

### DIFF
--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -94,7 +94,11 @@ class Annotation(db.Model):
         deleted_exists = exists(
             select(1)
             .select_from(DM)
-            .join(DD, DM.filepath.like(DD.filepath + literal("%")))
+            .join(
+                DD,
+                func.substring(DM.filepath, '[0-9a-fA-F\\-]{36}') ==
+                func.substring(DD.filepath, '[0-9a-fA-F\\-]{36}$')
+            )
             .where(
                 DM.documentmasterid == Document.documentmasterid,
                 DM.ministryrequestid == ministryrequestid,


### PR DESCRIPTION
**Context**

The Redaction App was timing out in PROD when fetching annotations. Root cause was a heavy SQL pattern: DISTINCT + JOIN on DocumentMaster.filepath LIKE DocumentDeleted.filepath || '%', producing large intermediate sets and long-running queries.

Related: WLR-2024-40712, MAG-2023-33856.

**Before (simplified):**


```
  LEFT JOIN (
    SELECT DISTINCT dm.documentmasterid
    FROM "DocumentMaster" dm
    JOIN "DocumentDeleted" dd
      ON dm.filepath LIKE dd.filepath || '%'
    WHERE dm.ministryrequestid = :id
  ) sq4 ON sq4.documentmasterid = "Documents".documentmasterid
  ...
  AND sq4.documentmasterid IS NULL
```


**After (anti-join):**


```
  AND NOT EXISTS (
    SELECT 1
    FROM "DocumentMaster" dm
    JOIN "DocumentDeleted" dd
      ON dm.filepath LIKE dd.filepath || '%'
    WHERE dm.documentmasterid = "Documents".documentmasterid
      AND dm.ministryrequestid = :id
  )

```

**Verification**

- Hit the annotations endpoint for the affected requests and confirm load completes.
- EXPLAIN (ANALYZE, BUFFERS) on the new query shows index scans/bitmap ops and no large HashAggregate for deleted-path filtering.

```

  EXPLAIN (ANALYZE, BUFFERS)
  SELECT
      "Annotations".pagenumber  AS "Annotations_pagenumber",
      "Annotations".annotation  AS "Annotations_annotation",
      "Documents".documentid    AS "Documents_documentid"
  FROM "Annotations"
           JOIN "Documents"
                ON "Annotations".documentid = "Documents".documentid
                    AND "Documents".foiministryrequestid = 8240
  
  LEFT OUTER JOIN (
      SELECT
          "DocumentMaster".documentmasterid AS documentmasterid
      FROM "DocumentMaster"
      WHERE "DocumentMaster".processingparentid IS NULL
        AND "DocumentMaster".ministryrequestid = 8240
  ) AS sq
  ON sq.documentmasterid = "Documents".documentmasterid
  
      LEFT OUTER JOIN (
      SELECT
      MAX("DocumentMaster".documentmasterid) AS documentmasterid
      FROM "DocumentMaster"
      WHERE "DocumentMaster".processingparentid IS NOT NULL
      AND "DocumentMaster".ministryrequestid = 8240
      GROUP BY "DocumentMaster".processingparentid
      ) AS sq3
      ON sq3.documentmasterid = "Documents".documentmasterid
  
      LEFT OUTER JOIN (
      SELECT
      "DocumentMaster".processingparentid AS processingparentid
      FROM "DocumentMaster"
      WHERE "DocumentMaster".processingparentid IS NOT NULL
      AND "DocumentMaster".ministryrequestid = 8240
      ) AS sq2
      ON sq2.processingparentid = "Documents".documentmasterid
  
  WHERE "Annotations".redactionlayerid IN (1)
    AND "Annotations".isactive = TRUE
    AND (sq.documentmasterid IS NOT NULL OR sq3.documentmasterid IS NOT NULL)
    AND sq2.processingparentid IS NULL
    AND NOT EXISTS (
      SELECT 1
      FROM "DocumentMaster" dm
               JOIN "DocumentDeleted" dd
                    ON substring(dm."filepath" from '[0-9a-fA-F\\-]{36}') = substring(dd."filepath" from '[0-9a-fA-F\\-]{36}$')
      WHERE dm."documentmasterid" = "Documents"."documentmasterid"
        AND dm."ministryrequestid" = 8240
  )
  
  ORDER BY
      "Documents".documentid,
      "Annotations".pagenumber,
      "Annotations".annotationid
  LIMIT 3500
      OFFSET 0;

```
