### PR TITLE
feat: add recordgroups filtering with attachment hierarchy support

### DIFF
--- a/api/reviewer_api/services/documentservice.py
+++ b/api/reviewer_api/services/documentservice.py
@@ -154,16 +154,17 @@ class documentservice:
                                 attachment["duplicatemasterid"],
                                 attachment["duplicateof"],
                             ) = self.__isduplicate(_att_in_properties, attachment)
-
-                (
-                    attachment["originalpagecount"],
-                    attachment["pagecount"],
-                    attachment["filename"],
-                    attachment["documentid"],
-                    attachment["version"],
-                    attachment["selectedfileprocessversion"],
-                    attachment["converteddocmasterid"]
-                ) = self.__getpagecountandfilename(attachment, _att_in_properties)
+                    
+                    # Always populate properties for attachments
+                    (
+                        attachment["originalpagecount"],
+                        attachment["pagecount"],
+                        attachment["filename"],
+                        attachment["documentid"],
+                        attachment["version"],
+                        attachment["selectedfileprocessversion"],
+                        attachment["converteddocmasterid"]
+                    ) = self.__getpagecountandfilename(attachment, properties)
         return record
 
     def __filterrecords(self, records):


### PR DESCRIPTION
Implement recordgroups parameter to filter documents by specific record IDs while preserving all attachments and converted files.