### PR TITLE
docs(api): introduce documentation for redline download, zipping, and summary generation flows

### DIFF
--- a/api/docs/DELETED_FILES_AND_PAGES_IN_FINAL_PACKAGE.md
+++ b/api/docs/DELETED_FILES_AND_PAGES_IN_FINAL_PACKAGE.md
@@ -1,0 +1,336 @@
+# Deleted Files and Pages in Final Package Workflow
+
+## Purpose
+
+This document explains how deleted content is handled when the application creates a final package for the applicant.
+
+There are two different deletion concepts in this codebase, and they behave differently:
+
+1. deleted files or records
+2. deleted pages inside otherwise active files
+
+The distinction matters:
+
+- deleted files are excluded before final-package generation starts
+- deleted pages remain part of an active document, but are removed from page mapping, final-package output, and summary calculations
+
+This document covers both the frontend and backend workflow.
+
+## Terminology
+
+### Deleted file
+
+A deleted file is represented in the backend by `DocumentDeleted`. It marks an entire document or record path as deleted for a request.
+
+Reference: [DocumentDeleted.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/models/DocumentDeleted.py)
+
+### Deleted page
+
+A deleted page is represented in the backend by `DocumentDeletedPages`. It marks one or more page numbers as deleted for a specific active document.
+
+Reference: [DocumentDeletedPages.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/models/DocumentDeletedPages.py)
+
+## High-Level Behavior
+
+### Deleted files
+
+Deleted files are excluded upstream, before the final-package workflow builds its `documentList`.
+
+Effect:
+
+- the user does not package them
+- they are not stitched into the final PDF
+- they are not included in summary generation
+- they are not part of the final ZIP
+
+### Deleted pages
+
+Deleted pages remain associated with an active document, but they are removed from:
+
+- frontend page mapping
+- stitched-page calculations
+- final PDF assembly
+- summary generation
+
+Effect:
+
+- the document can still appear in the final package
+- the deleted pages inside that document are excluded
+
+## End-to-End Flow
+
+1. A user deletes a whole file or specific pages.
+2. The backend persists either `DocumentDeleted` or `DocumentDeletedPages`.
+3. A page-calculator job is triggered so downstream page metadata is refreshed.
+4. The frontend loads the request documents and deleted-page metadata.
+5. The final-package workflow builds page mappings using only non-deleted pages.
+6. The frontend removes additional pages for package rules such as duplicate, NR, withheld-in-full, and phase filtering.
+7. The final-package PDF is uploaded to object storage.
+8. The API receives the final-package payload and triggers summary generation and zipping.
+9. The backend summary generator excludes deleted pages again from summary calculations.
+10. The zipper packages only the already-generated final PDF and summary PDF.
+
+## Part 1: Whole Deleted Files
+
+### How a file is marked deleted
+
+The backend file-deletion path is implemented in [documentservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/services/documentservice.py#L429).
+
+`deletedocument(...)`:
+
+- inserts rows into `DocumentDeleted`
+- stores the deleted path prefix
+- triggers a page-calculator job on success
+
+This means file deletion is a backend data decision, not just a frontend filter.
+
+### How deleted files are resolved
+
+The system uses `DocumentMaster.getdeleted(ministryrequestid)` to resolve which document masters are deleted for the request.
+
+Reference: [DocumentMaster.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/models/DocumentMaster.py#L167)
+
+That result is then used to compute active document IDs:
+
+- [Documents.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/models/Documents.py#L167)
+
+`getactivedocumentidsbyrequest(...)` excludes documents whose `documentmasterid` is in the deleted set.
+
+### Frontend consequence
+
+By the time the frontend builds the final package, deleted files are generally already missing from the request’s active `documentList`.
+
+In practical terms:
+
+- the deleted file does not appear in the package builder inputs
+- the deleted file is never stitched into the applicant package
+- the deleted file is absent from `summarydocuments.sorteddocuments`
+
+### Backend consequence
+
+Because deleted files are absent from the active document list:
+
+- the presigned final-package endpoint is never asked to create a package output for them
+- the final stitched PDF never contains them
+- summary generation never counts them
+- zipping never sees them
+
+## Part 2: Deleted Pages
+
+Deleted pages are handled separately from deleted files.
+
+### How deleted pages are stored
+
+The service [docdeletedpageservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/services/docdeletedpageservice.py#L12) creates `DocumentDeletedPages` rows and updates page counts.
+
+It also triggers a page-calculator job after successful persistence.
+
+### How deleted pages are loaded
+
+The frontend maintains deleted-page state in Redux as `deletedDocPages`.
+
+The main document/home workflow fetches that state and passes it into the page-mapping builder in [Home.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/Home.js#L128).
+
+## Frontend Workflow for Deleted Pages in Final Package
+
+The final-package frontend logic lives in [useSaveResponsePackage.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveResponsePackage.js).
+
+### Step 1: Build page mappings without deleted pages
+
+The initial page-mapping logic uses `getDocumentPages(...)`:
+
+- [utils.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/utils.js#L167)
+
+That helper:
+
+- reads deleted pages for the document from `deletedDocPages`
+- builds the document page array from `1..originalPagecount`
+- omits any deleted page numbers
+
+This means deleted pages are removed before stitched page numbering is calculated.
+
+### Step 2: Build stitched page lookup from filtered page arrays
+
+`prepareMapperObj(...)` in [Home.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/Home.js#L209) uses those filtered page arrays to construct:
+
+- `stitchedPageLookup`
+- `docIdLookup`
+- `redlineDocIdLookup`
+
+Because deleted pages are already missing here:
+
+- they receive no stitched page number
+- later steps cannot accidentally map them into the final package
+
+### Step 3: Remove additional pages for final-package rules
+
+Inside `saveResponsePackage(...)`, the frontend builds `pagesToRemove` from package rules:
+
+- duplicate pages
+- not responsive pages
+- phase exclusions
+- pages without flags in phase mode
+
+Reference: [useSaveResponsePackage.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveResponsePackage.js#L245)
+
+Important point:
+
+- deleted pages are not added here because they were already removed from the stitched page mapping earlier
+
+### Step 4: Remove pages from the package PDF
+
+After applying redactions, the frontend removes the calculated `pagesToRemove` from the in-browser PDF:
+
+- [useSaveResponsePackage.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveResponsePackage.js#L320)
+
+Because deleted pages never received stitched page positions, they are already absent from the package at this stage.
+
+### Step 5: Remove withheld-in-full pages after page stamping
+
+After page numbers are stamped, the frontend recalculates and removes `Withheld in Full` pages:
+
+- [useSaveResponsePackage.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveResponsePackage.js#L343)
+
+This is separate from deleted-page logic, but the end result is similar: those pages do not survive into the uploaded final PDF.
+
+### Step 6: Upload only the filtered final package PDF
+
+The frontend uploads the final applicant package PDF to object storage:
+
+- [useSaveResponsePackage.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveResponsePackage.js#L408)
+
+At this point:
+
+- deleted files are already absent from the source document list
+- deleted pages are already absent from the uploaded PDF
+
+## Final-Package Payload Impact
+
+The frontend final-package payload contains:
+
+- one uploaded final package PDF in `attributes[0].files`
+- `summarydocuments`
+- category metadata
+
+Reference: [useSaveResponsePackage.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveResponsePackage.js#L214)
+
+Deleted content affects this payload indirectly:
+
+### Deleted files
+
+- deleted files do not appear in `documentList`
+- therefore they do not contribute to the stitched final PDF
+- therefore they do not contribute to `summarydocuments`
+
+### Deleted pages
+
+- deleted pages do not receive stitched page numbers
+- therefore they do not exist in the uploaded final package PDF
+- the payload still references the same document ID, but only the remaining pages survive
+
+## Backend Summary Generation Impact
+
+Even though deleted pages are already filtered out on the frontend, the backend summary generator excludes them again when computing summary ranges and sections.
+
+The summary path is implemented in:
+
+- [redactionsummaryservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/redactionsummaryservice.py)
+- [redactionsummary.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dts/redactionsummary.py)
+
+### How backend summary generation gets deleted pages
+
+`documentpageflag().getdeletedpages(...)` reads deleted-page rows from `DocumentDeletedPages`.
+
+Reference: [documentpageflag.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dal/documentpageflag.py#L219)
+
+### How deleted pages affect summary generation
+
+The summary builder uses deleted pages to:
+
+- exclude deleted pages from section calculations
+- avoid counting deleted pages when computing stitched page ranges
+- avoid including deleted pages in response-package summaries
+
+Relevant code:
+
+- [redactionsummary.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dts/redactionsummary.py#L62)
+- [redactionsummary.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dts/redactionsummary.py#L470)
+- [redactionsummary.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dts/redactionsummary.py#L569)
+
+This is an important defense-in-depth behavior:
+
+- the frontend excludes deleted pages from the PDF
+- the backend excludes deleted pages from the summary data model
+
+### Deleted files and backend summary generation
+
+Deleted files are not typically present in `summarydocuments.sorteddocuments` because they were excluded earlier from the active document set.
+
+As a result:
+
+- the summary generator does not see them as package inputs
+- they do not contribute ranges, counts, or sections
+
+## Backend Zipping Impact
+
+The zipper does not make deletion decisions itself.
+
+The zipper only packages whatever files are listed in `filestozip`.
+
+Reference: [zipperservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperservice.py#L105)
+
+That means:
+
+### Deleted files
+
+- never reach the zipper as independent source files for the final package
+- are absent because they were excluded earlier from the active package build
+
+### Deleted pages
+
+- are absent because the uploaded final package PDF already excludes them
+- the zipper simply packages the filtered final PDF and generated summary PDF
+
+## Practical Examples
+
+### Example 1: Whole file deleted
+
+1. A record is marked deleted through `DocumentDeleted`.
+2. The request’s active document set no longer includes that record.
+3. The frontend final-package flow never sees it in `documentList`.
+4. The final package PDF excludes it completely.
+5. The summary excludes it completely.
+6. The ZIP excludes it completely.
+
+### Example 2: Two pages deleted from an active document
+
+1. Pages `3` and `4` are stored in `DocumentDeletedPages`.
+2. The frontend mapper builds page arrays without `3` and `4`.
+3. The stitched final-package PDF is generated from the remaining pages only.
+4. The backend summary generator also excludes pages `3` and `4`.
+5. The ZIP contains the final package PDF without those pages.
+
+## Decision Summary
+
+### When content is excluded before final package creation
+
+- whole deleted files
+- deleted pages via frontend page mapping
+
+### When content is excluded again downstream
+
+- deleted pages during summary generation
+
+### What the zipper does
+
+- no independent deletion logic
+- packages the already-filtered outputs
+
+## Key Takeaway
+
+The final-package workflow handles deleted files and deleted pages in different layers:
+
+- deleted files are excluded at the data-selection stage
+- deleted pages are excluded at page-mapping, PDF-generation, and summary-generation stages
+
+By the time zipping happens, deletion decisions have already been made. The ZIP contains only the filtered final package and filtered summary outputs.

--- a/api/docs/FRONTEND_TRIGGERDOWNLOADREDLINE_PAYLOAD.md
+++ b/api/docs/FRONTEND_TRIGGERDOWNLOADREDLINE_PAYLOAD.md
@@ -1,0 +1,464 @@
+# Frontend Process for Building `triggerdownloadredline` Payload
+
+## Purpose
+
+This document describes how the frontend builds the request payload sent to `POST /api/triggerdownloadredline`.
+
+It covers all frontend variants that use the same endpoint:
+
+- standard redline
+- consult package
+- OIPC redline
+- OIPC review redline
+- phase-based redline
+
+The implementation is centered in [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js).
+
+## High-Level Flow
+
+1. The user opens the package modal from the document-review UI.
+2. The modal captures package options such as comments, duplicate pages, NR pages, consult options, and phase.
+3. The frontend determines which documents belong in each package group.
+4. The frontend calls the backend presigned-URL endpoint to get upload targets and package metadata.
+5. The frontend builds the base `redlineZipperMessage`.
+6. The frontend stitches and post-processes PDFs in the browser.
+7. The frontend uploads the final stitched PDFs to object storage.
+8. The frontend converts the uploaded files plus incompatible files into `attributes[*].files`.
+9. Once all groups are ready, the frontend POSTs the final payload to `/api/triggerdownloadredline`.
+
+## Main Entry Points
+
+### Payload creation hook
+
+- [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js)
+
+### Modal inputs
+
+- [ConfirmationModal.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/ConfirmationModal.js)
+
+### API call
+
+- [docReviewerService.tsx](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/apiManager/services/docReviewerService.tsx#L413)
+
+### Presigned URL request
+
+- [foiOSSService.tsx](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/apiManager/services/foiOSSService.tsx#L42)
+
+## User Inputs That Affect the Payload
+
+The modal drives several payload fields.
+
+### Standard redline options
+
+When `modalFor === "redline"`, the user can control:
+
+- `includeComments`
+- `includeNRPages`
+- `includeDuplicatePages`
+- `redlinePhase` when phases are enabled
+
+Reference: [ConfirmationModal.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/ConfirmationModal.js#L82)
+
+### Consult package options
+
+When `modalFor === "consult"`, the user can control:
+
+- which public bodies or custom consult bodies are included
+- `includeNRPages`
+- `includeDuplicatePages`
+- `consultApplyRedlines`
+- `consultApplyRedactions`
+
+These inputs affect both which files are generated and what metadata is carried in the payload.
+
+### OIPC behavior
+
+OIPC behavior is determined by:
+
+- the selected current layer
+- the requested `layertype`
+
+The modal suppresses phase selection when `validoipcreviewlayer` is true.
+
+## Core State Used to Build the Payload
+
+The hook stores package state in several React state variables:
+
+| State | Purpose |
+| --- | --- |
+| `redlineCategory` | Frontend mode such as `redline`, `consult`, or `oipcreview`. |
+| `redlinePhase` | Selected phase for phased redline output. |
+| `includeComments` | Controls whether comments are included in the exported PDF and payload metadata. |
+| `includeNRPages` | Controls NR page inclusion and payload metadata. |
+| `includeDuplicatePages` | Controls duplicate-page inclusion and payload metadata. |
+| `consultApplyRedlines` | Consult-specific toggle for preserving transparent redlines. |
+| `consultApplyRedactions` | Consult-specific toggle for applying NR redactions. |
+| `selectedPublicBodyIDs` | Consult-specific grouping keys. |
+| `redlineZipperMessage` | The in-progress payload object eventually posted to the API. |
+| `redlineStitchInfo` | Per-group upload targets and document IDs. |
+| `redlineIncompatabileMappings` | Incompatible files that must be included without stitching. |
+
+## Step 1: Determine Package Category
+
+The frontend decides the API `category` by calling `getzipredlinecategory(layertype)`.
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L1031)
+
+Rules:
+
+| Condition | Payload `category` |
+| --- | --- |
+| `redlineCategory === "consult"` | `consultpackage` |
+| current layer is `oipc` and `layertype === "oipcreview"` | `oipcreviewredline` |
+| current layer is `oipc` and not OIPC review | `oipcredline` |
+| `redlineCategory === "redline"` and `redlinePhase` is set | `redline_phase{phase}` |
+| otherwise | `redline` |
+
+This is the main frontend switch that determines which downstream backend path will run.
+
+## Step 2: Determine Package Groups
+
+The frontend groups documents differently depending on variant.
+
+### Standard redline and OIPC variants
+
+For `redline` and `oipcreview`, documents are grouped by division.
+
+The helper `getDivisionDocumentMappingForRedline(...)` creates entries like:
+
+```json
+{
+  "divisionid": 87,
+  "divisionname": "Minister of State",
+  "documentlist": [...],
+  "incompatableList": [...]
+}
+```
+
+### Consult package
+
+For consult packages, the frontend reuses the same division-oriented packaging flow, but substitutes selected public bodies as the grouping key.
+
+Each selected public body or custom consult body becomes a package group.
+
+This is why consult packaging still produces `divisionid` and `divisionname`-style payload entries later, even though the logical grouping is by consultees/public bodies.
+
+## Step 3: Request Presigned URLs and Package Metadata
+
+Before it can build final file entries, the frontend calls:
+
+- [getFOIS3DocumentRedlinePreSignedUrl](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/apiManager/services/foiOSSService.tsx#L42)
+
+That request includes:
+
+- `ministryrequestID`
+- `requestType`
+- grouped `divdocumentList`
+- `layertype`
+- current layer name
+- `redlinePhase`
+
+The backend response supplies:
+
+- `requestnumber`
+- `bcgovcode`
+- `issingleredlinepackage`
+- top-level `s3path_save` for single-package mode
+- per-group `s3path_save`
+- per-document `s3path_load`
+- normalized `divdocumentList`
+
+Reference: [foiflowmasterdata.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/resources/foiflowmasterdata.py#L310)
+
+This backend call is what gives the frontend enough information to finish the payload.
+
+## Step 4: Build the Base Payload Object
+
+After the presigned-URL response returns, the frontend initializes `redlineZipperMessage`:
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L1442)
+
+Base shape:
+
+```json
+{
+  "ministryrequestid": "<foiministryrequestid>",
+  "category": "<derived-category>",
+  "attributes": [],
+  "requestnumber": "<from-presigned-response>",
+  "bcgovcode": "<from-presigned-response>",
+  "summarydocuments": { "...": "..." },
+  "redactionlayerid": "<current layer id>",
+  "requesttype": "<request type>"
+}
+```
+
+### Field sources
+
+| Payload field | Source |
+| --- | --- |
+| `ministryrequestid` | `useParams().foiministryrequestid` |
+| `category` | `getzipredlinecategory(layertype)` |
+| `attributes` | built later after PDF upload/incompatible-file merge |
+| `requestnumber` | presigned-URL response |
+| `bcgovcode` | presigned-URL response |
+| `summarydocuments` | `prepareredlinesummarylist(stitchDocuments)` |
+| `redactionlayerid` | current Redux layer |
+| `requesttype` | request info from Redux |
+
+## Step 5: Build `summarydocuments`
+
+The frontend creates `summarydocuments` by calling `prepareredlinesummarylist(stitchDocuments)`.
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L1044)
+
+The structure contains:
+
+- `sorteddocuments`: a globally ordered document list
+- `pkgdocuments`: package groups keyed by division or consult grouping
+
+Typical shape:
+
+```json
+{
+  "sorteddocuments": [26586, 26587, 26590],
+  "pkgdocuments": [
+    { "divisionid": "87", "documentids": [26586, 26587] },
+    { "divisionid": "92", "documentids": [26590] }
+  ]
+}
+```
+
+Notes:
+
+- In single-package mode, the frontend uses `"0"` as the synthetic package key.
+- For consult packages, the logical grouping is by selected public body, but the generated structure still uses `divisionid`-style keys.
+
+## Step 6: Stitch and Post-Process PDFs
+
+Once the base payload exists, the frontend generates the actual PDF files that will later be referenced by `attributes[*].files`.
+
+There are two broad stitching modes:
+
+### Single-package mode
+
+If `issingleredlinepackage === "Y"`, the frontend stitches all relevant documents into one package output.
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L1087)
+
+### Per-group mode
+
+If `issingleredlinepackage === "N"`, the frontend creates one stitched PDF per division or consult group.
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L1067)
+
+## Step 7: Variant-Specific PDF Processing
+
+The uploaded PDFs differ by variant before they are turned into payload file entries.
+
+### Standard redline
+
+Standard redline flow:
+
+- stamps page numbers
+- removes pages excluded by page mappings
+- adds duplicate or NR watermarks when needed
+- exports annotations
+- optionally re-imports comments if `includeComments` is enabled
+
+### Phase-based redline
+
+Phase-based redline is still a redline payload, but:
+
+- the category becomes `redline_phase{n}`
+- page selection logic restricts the package to pages belonging to the chosen phase
+- the per-attribute `phase` field is populated
+
+### OIPC review redline
+
+For `redlineCategory === "oipcreview"`:
+
+- the category becomes `oipcreviewredline`
+- the frontend identifies `s. 14` redactions
+- those redactions are applied before upload
+- the uploaded PDF becomes the source file referenced in the payload
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L2059)
+
+### OIPC redline
+
+For the OIPC layer without OIPC review mode:
+
+- the category becomes `oipcredline`
+- the flow still uses the same payload-construction path
+- OIPC-specific category selection happens earlier through `getzipredlinecategory(...)`
+
+### Consult package
+
+For `redlineCategory === "consult"`:
+
+- if `consultApplyRedlines` is false, transparent redline annotations are removed from the exported package
+- if `consultApplyRedactions` is true, NR redactions are applied
+- pages outside the current consult group are removed
+- consult-specific page filtering is applied before upload
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L2160)
+
+## Step 8: Upload Stitched PDFs to Object Storage
+
+After post-processing, the frontend uploads each final PDF to the `s3path_save` returned by the presigned endpoint.
+
+Reference:
+
+- [saveFilesinS3](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/apiManager/services/foiOSSService.tsx#L78)
+- [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L2108)
+
+Only after this upload succeeds can the frontend add the file to the final API payload.
+
+## Step 9: Convert Uploaded Files Into `attributes[]`
+
+The final payload is assembled incrementally in `prepareMessageForRedlineZipping(...)`.
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L1536)
+
+For each package group, the frontend builds:
+
+```json
+{
+  "divisionid": 87,
+  "divisionname": "Minister of State",
+  "files": [
+    {
+      "filename": "Minister of State/ECC-4535-455 - redline - Minister of State.pdf",
+      "s3uripath": "https://..."
+    }
+  ],
+  "includeduplicatepages": true,
+  "includenrpages": true,
+  "phase": null,
+  "includecomments": true,
+  "documentsetid": 158
+}
+```
+
+### Per-attribute field sources
+
+| Field | Source |
+| --- | --- |
+| `divisionid` | current group metadata, only set in multi-package mode |
+| `divisionname` | current group metadata, only set in multi-package mode |
+| `files` | stitched upload path plus incompatible files |
+| `includeduplicatepages` | current checkbox state |
+| `includenrpages` | current checkbox state |
+| `phase` | `redlinePhase` only when `redlineCategory === "redline"` |
+| `includecomments` | current checkbox state |
+| `documentsetid` | URL query parameter `documentsetid` |
+
+### How `files[]` is built
+
+The `files` array is a merge of:
+
+1. the stitched PDF just uploaded to S3
+2. any incompatible files that could not participate in stitching
+
+If the package is multi-group:
+
+- the stitched filename is prefixed with `divisionname/`
+
+If the package is single-group:
+
+- the filename is just the uploaded PDF filename
+
+This explains why redline ZIPs preserve division folders in multi-package mode.
+
+## Step 10: Final Dispatch to the API
+
+Each successful group upload appends one `attributes[]` entry to `redlineZipperMessage`.
+
+When the number of completed attribute entries matches the expected group count, the frontend calls:
+
+- [triggerDownloadRedlines](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/apiManager/services/docReviewerService.tsx#L413)
+
+That function POSTs the final payload to:
+
+- `/api/triggerdownloadredline`
+
+## Final Payload Shape
+
+The final frontend payload sent to the API looks like:
+
+```json
+{
+  "ministryrequestid": "21965",
+  "category": "redline",
+  "attributes": [
+    {
+      "divisionid": 87,
+      "divisionname": "Minister of State",
+      "files": [
+        {
+          "filename": "Minister of State/ECC-4535-455 - redline - Minister of State.pdf",
+          "s3uripath": "https://..."
+        }
+      ],
+      "includeduplicatepages": true,
+      "includenrpages": true,
+      "phase": null,
+      "includecomments": true,
+      "documentsetid": 158
+    }
+  ],
+  "requestnumber": "ECC-4535-455",
+  "bcgovcode": "ecc",
+  "summarydocuments": {
+    "sorteddocuments": [26586],
+    "pkgdocuments": [
+      {
+        "divisionid": "87",
+        "documentids": [26586]
+      }
+    ]
+  },
+  "redactionlayerid": 1,
+  "requesttype": "general"
+}
+```
+
+## Variant Summary
+
+### Standard redline
+
+- `category = "redline"`
+- `phase = null`
+- comments, duplicate pages, and NR pages come from modal checkboxes
+
+### Phase-based redline
+
+- `category = "redline_phase{n}"`
+- `attributes[*].phase = n`
+- phase also influences which pages are stitched and uploaded
+
+### Consult package
+
+- `category = "consultpackage"`
+- groups are selected public bodies rather than divisions
+- consult toggles affect the actual uploaded PDF content
+- `phase` remains `null`
+
+### OIPC redline
+
+- `category = "oipcredline"`
+- payload creation path is otherwise the same as standard redline
+
+### OIPC review redline
+
+- `category = "oipcreviewredline"`
+- `s. 14` redactions are applied before upload
+
+## Important Implementation Details
+
+- The frontend does not send source document paths directly from the original document list. It sends the uploaded stitched PDF paths returned by the presigned flow plus incompatible-file paths.
+- The payload is built only after object-storage upload succeeds.
+- `documentsetid` is pulled from the URL query string, not from Redux state.
+- `summarydocuments` is derived from the stitched document grouping, not from the uploaded `files[]` list.
+- The payload object is mutated incrementally through `zipServiceMessage.attributes.push(...)`, then dispatched once all package groups are complete.

--- a/api/docs/SUMMARY_GENERATION.md
+++ b/api/docs/SUMMARY_GENERATION.md
@@ -1,0 +1,270 @@
+# Summary Generation
+
+## Purpose
+
+This document describes how summary PDFs are generated for redline and response-package downloads in FOI Doc Reviewer.
+
+The summary generator is not executed inside the API request thread. The API accepts a package request, persists job state, publishes a stream message, and the downstream document service creates the summary PDF asynchronously before handing the package off to the zipper service.
+
+## End-to-End Flow
+
+1. The frontend prepares `summarydocuments` and package metadata.
+2. The API receives `POST /api/triggerdownloadredline` or `POST /api/triggerdownloadfinalpackage`.
+3. The API stores a `PDFStitchJob` row with status `pushedtostream`.
+4. The API publishes a message to the document-service Redis stream.
+5. `documentservicestreamreader` consumes the message.
+6. `redactionsummaryservice` generates one or more summary PDFs unless the category suppresses summary generation.
+7. Generated summary PDFs are uploaded to object storage.
+8. The original package files plus the generated summary PDFs are forwarded to the zipper stream.
+
+## Entry Points
+
+### API layer
+
+- [redaction.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/resources/redaction.py#L305) accepts redline package requests.
+- [redaction.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/resources/redaction.py#L332) accepts final package requests.
+- [radactionservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/services/radactionservice.py#L125) creates the job record and publishes the stream message.
+
+### Document service layer
+
+- [documentservicestreamreader.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/rstreamio/reader/documentservicestreamreader.py#L60) consumes the stream message.
+- [redactionsummaryservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/redactionsummaryservice.py#L13) orchestrates summary generation.
+- [redactionsummary.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dts/redactionsummary.py#L7) builds the summary data model.
+- [documentgenerationservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/documentgenerationservice.py#L30) renders the PDF via CDOGS.
+- [zippingservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/zippingservice.py#L6) appends generated summaries to `filestozip` and forwards the package.
+
+## Input Contract
+
+Summary generation depends on the stream payload produced by the API. The key fields are:
+
+| Field | Description |
+| --- | --- |
+| `category` | Determines summary template, page-flag behavior, and file naming. |
+| `requestnumber` | Used in the summary file name and rendered content. |
+| `bcgovcode` | Enables ministry-specific behavior such as MCF personal request handling. |
+| `attributes` | Carries division/package metadata and points at the stitched package PDFs already uploaded to object storage. |
+| `summarydocuments.sorteddocuments` | Canonical document order used to calculate stitched page ranges. |
+| `summarydocuments.pkgdocuments` | Package grouping. For redline this is usually per division; for response package it is typically a single package entry. |
+| `redactionlayerid` | Determines which redaction layer is queried for sections and page flags. |
+| `requesttype` | Used for special-case logic, especially `mcf` + `personal`. |
+| `phase` | Restricts summary content for phased redline and phased response-package categories. |
+| `documentsetid` | Enables record-group expansion before summary generation. |
+
+## Where `summarydocuments` Comes From
+
+The frontend builds `summarydocuments` before calling the package endpoints.
+
+### Redline flow
+
+For redline packages, the frontend groups document IDs by division and also creates a globally ordered `sorteddocuments` list.
+
+Reference: [useSaveRedlineForSignOff.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js#L1044)
+
+Typical shape:
+
+```json
+{
+  "sorteddocuments": [26586, 26587, 26590],
+  "pkgdocuments": [
+    { "divisionid": 87, "documentids": [26586, 26587] },
+    { "divisionid": 92, "documentids": [26590] }
+  ]
+}
+```
+
+### Response package flow
+
+For response packages, the frontend usually builds a single package entry with `divisionid = 0`.
+
+Reference: [useSaveResponsePackage.js](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/web/src/components/FOI/Home/CreateResponsePDF/useSaveResponsePackage.js#L143)
+
+Typical shape:
+
+```json
+{
+  "sorteddocuments": [301, 302, 303],
+  "pkgdocuments": [
+    { "divisionid": 0, "documentids": [301, 302, 303] }
+  ]
+}
+```
+
+### MCF personal request variant
+
+For `bcgovcode = "mcf"` and `requesttype = "personal"`, response-package summaries use record-level groupings instead of a flat document list. Each record carries a generated `recordname` and its own `documentids`.
+
+Typical shape:
+
+```json
+{
+  "sorteddocuments": [301, 302, 303],
+  "pkgdocuments": [
+    {
+      "divisionid": 0,
+      "documentids": [301, 302, 303],
+      "records": [
+        { "recordname": "APPLICANT - MEDICAL - T123", "documentids": [301, 302] },
+        { "recordname": "MEDICAL - T124", "documentids": [303] }
+      ]
+    }
+  ]
+}
+```
+
+## Category Behavior
+
+### Categories that generate summaries
+
+- `redline`
+- `redline_phase{n}`
+- `responsepackage`
+- `responsepackage_phase{n}`
+- `oipcreviewredline`
+- `oipcredline`
+- `openinfo`
+
+### Category that skips summary generation
+
+- `consultpackage`
+
+`consultpackage` returns no summary files and goes directly to the zipper flow.
+
+## Template Selection
+
+The document service chooses a CDOGS template based on category and request type.
+
+| Condition | Template |
+| --- | --- |
+| `bcgovcode == "mcf"` and `requesttype == "personal"` and response-package/openinfo flow | `CFD_responsepackage_redaction_summary` |
+| `category` contains `responsepackage` or equals `openinfo` | `responsepackage_redaction_summary` |
+| Otherwise | `redline_redaction_summary` |
+
+Template selection logic lives in [redactionsummaryservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/redactionsummaryservice.py#L24).
+
+## Summary Data Construction
+
+The summary builder has two major branches.
+
+### Standard branch
+
+Most categories use `__packaggesummary(...)` in [redactionsummary.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dts/redactionsummary.py#L26).
+
+This branch:
+
+1. Resolves the effective redaction layer.
+2. Reads `sorteddocuments` to establish stitched document order.
+3. Fetches stitched page counts and, for phased response packages, original page counts.
+4. Loads page flags and deleted-page information from the database.
+5. Filters the working page set based on category and phase.
+6. Maps flagged pages to stitched page numbers and redaction sections.
+7. Produces grouped summary entries such as consult, duplicate, not responsive, and phase-related sections depending on the category.
+
+For non-MCF response-package and openinfo requests, the service consolidates all grouped section entries into one flat, range-sorted list before rendering.
+
+### MCF personal response-package branch
+
+`mcf` personal response-package and openinfo requests use `__packagesummaryforcfdrequests(...)` in [redactionsummary.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dts/redactionsummary.py#L128).
+
+This branch:
+
+1. Reads record groupings from `summarydocuments.pkgdocuments[0].records`.
+2. Maps page flags to stitched pages.
+3. Applies phase filtering when needed.
+4. Computes page ranges per record.
+5. Associates redaction sections with each record.
+6. Produces a record-oriented summary model instead of the standard grouped-flag model.
+
+## Page-Flag Rules
+
+Page-flag selection is category-sensitive.
+
+| Category | Page flags loaded |
+| --- | --- |
+| `responsepackage`, `openinfo` | `Consult`, `Not Responsive`, `Duplicate`, `Phase` |
+| All other summary-generating categories | `Consult`, `Phase` |
+
+This is implemented in [redactionsummaryservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/redactionsummaryservice.py#L108).
+
+Additional rules:
+
+- `oipcreviewredline` removes duplicate and not-responsive sections from the final summary.
+- `redline_phase{n}` and `responsepackage_phase{n}` restrict the summary to pages associated with the selected phase.
+- Deleted pages are excluded from page calculations.
+
+## One Summary per Package Group
+
+The service iterates `summarydocuments.pkgdocuments` and generates one summary PDF per entry that contains `documentids`.
+
+In practice:
+
+- Redline usually generates one summary per division.
+- Response package usually generates one summary for the package.
+- MCF personal response package usually generates one summary for the package, but with record-level grouping inside the rendered summary.
+
+## File Naming and Upload Location
+
+The summary service derives the upload target from the first stitched file in the matching `attributes` entry.
+
+Summary names are category-aware:
+
+| Category pattern | Output naming rule |
+| --- | --- |
+| `responsepackage_phase{n}` | `{requestnumber} - Phase {n} - summary.pdf` |
+| `responsepackage` | `{requestnumber} - summary.pdf` |
+| `redline_phase{n}` | `{requestnumber} - Redline - Phase {n} - summary.pdf` |
+| `oipcreviewredline` | `{requestnumber} - Redline - summary.pdf` |
+| `openinfo` | `Redaction_Summary_{requestnumber}.pdf` |
+| Other redline-like categories | `{requestnumber} - {category} - {divisionname?} - summary.pdf` |
+
+The naming logic is in [redactionsummaryservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/redactionsummaryservice.py#L92).
+
+## Rendering
+
+After the summary data model is assembled:
+
+1. `documentgenerationservice.generate_pdf(...)` resolves the configured template.
+2. The service checks whether the CDOGS template hash is already cached.
+3. If needed, it uploads the template to CDOGS and stores the returned hash code.
+4. CDOGS renders the final PDF.
+
+Rendering logic lives in [documentgenerationservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/documentgenerationservice.py#L30).
+
+## Job Status Tracking
+
+The document service records summary-specific job activity in `PDFStitchJob` using `category + "-summary"`.
+
+Observed states:
+
+- `redactionsummarystarted`
+- `redactionsummaryuploaded`
+- `error` with message `summary generation failed`
+
+Reference: [pdfstitchjobactivity.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/dal/pdfstitchjobactivity.py#L15)
+
+## Handoff to Zipping
+
+Once summary generation completes:
+
+1. Generated summary files are appended to the original `filestozip`.
+2. The message is normalized back to JSON strings.
+3. The combined package request is sent to the zipper stream.
+
+Reference: [zippingservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/zippingservice.py#L6)
+
+This means the final ZIP contains:
+
+- The already-uploaded stitched package PDF files.
+- The generated summary PDF files, if the category produces summaries.
+
+## Failure Behavior
+
+- Summary generation failures are caught inside `redactionsummaryservice.processmessage(...)`.
+- The service records an error job activity row.
+- It returns whatever summary files were successfully created before the failure, if any.
+- The message is still forwarded to the zipper service, which means packaging can continue even if no summary PDF was generated.
+
+## Practical Constraints
+
+- Summary generation assumes the stitched package PDFs already exist in object storage.
+- The quality of the summary depends directly on `summarydocuments.sorteddocuments`, `pkgdocuments`, page flags, deleted pages, and section metadata being consistent.
+- `documentsetid` can alter the effective document set by expanding the document list from record groups before summary rendering.

--- a/api/docs/TRIGGER_DOWNLOAD_REDLINE.md
+++ b/api/docs/TRIGGER_DOWNLOAD_REDLINE.md
@@ -1,0 +1,137 @@
+# FOI DOC REVIEWER API
+
+## `POST /api/triggerdownloadredline`
+
+Triggers creation of a redline download package after the frontend has already generated and uploaded the per-division or single-package redline PDFs to object storage.
+
+This endpoint does not return the ZIP file. It records a PDF stitch job and publishes a message to the downstream document service stream, where summary generation and zipping are completed asynchronously.
+
+### Authentication
+
+- Requires bearer token authentication.
+- The route is protected by `@auth.require` in the API layer.
+
+### What the endpoint does
+
+When a valid request is received, the API:
+
+1. Validates the payload with `RedlineSchema`.
+2. Creates a `PDFStitchJob` row with status `pushedtostream`.
+3. Flattens `attributes[*].files[*]` into a `filestozip` list.
+4. Publishes a message to the document service Redis stream.
+5. Returns a synchronous acknowledgement to the caller.
+
+### Request contract
+
+#### Top-level fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `ministryrequestid` | `string` | Yes | FOI request identifier. Stored as integer in job status creation. |
+| `category` | `string` | Yes | Usually `redline`. Phase-based variants are also supported by downstream logic. |
+| `requestnumber` | `string` | Yes | Human-readable FOI request number, for example `ECC-4535-455`. |
+| `bcgovcode` | `string` | Yes | Ministry code, for example `ecc`. |
+| `attributes` | `array` | Yes | One entry per division/package payload being zipped. |
+| `summarydocuments` | `object` | No | Document ordering/grouping metadata used by downstream summary generation. |
+| `redactionlayerid` | `integer` | Yes | Redaction layer identifier, for example `1` for Redline. |
+| `requesttype` | `string` | Yes | Request classification, for example `general` or `personal`. |
+
+#### `attributes[]` fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `divisionid` | `integer` | No | Present for multi-division redline packages. |
+| `divisionname` | `string` | No | Used for division-specific packaging and naming. |
+| `files` | `array` | Yes | Files that should be included in the output ZIP. |
+| `includeduplicatepages` | `boolean` | No | Indicates duplicate-page content should be included in the package. |
+| `includenrpages` | `boolean` | No | Indicates NR pages should be included. |
+| `phase` | `integer` or `null` | No | Used for phase-based redline generation. |
+| `includecomments` | `boolean` | No | Indicates comment content should be included in the generated package. |
+| `documentsetid` | `integer` | No | Optional grouping identifier carried downstream. |
+
+#### `attributes[].files[]` fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `filename` | `string` | Yes | ZIP entry name. Can include folder segments such as `Minister of State/...pdf`. |
+| `s3uripath` | `string` | Yes | Source object storage path for the file to zip. |
+
+#### `summarydocuments` fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `sorteddocuments` | `array<int>` | No | Ordered list of source document IDs. |
+| `pkgdocuments` | `array<object>` | No | Groupings used by summary generation. |
+
+#### `summarydocuments.pkgdocuments[]` fields
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `divisionid` | `integer` | No | Division associated with the document group. |
+| `documentids` | `array<int>` | Yes | Documents represented in that package group. |
+
+### Sample request
+
+```bash
+curl 'https://dev-reviewer-api.apps.silver.devops.gov.bc.ca/api/triggerdownloadredline' \
+  -H 'Accept: application/json, text/plain, */*' \
+  -H 'Authorization: Bearer <TOKEN>' \
+  -H 'Content-Type: application/json' \
+  --data-raw '{
+    "ministryrequestid": "21965",
+    "category": "redline",
+    "attributes": [
+      {
+        "divisionid": 87,
+        "divisionname": "Minister of State",
+        "files": [
+          {
+            "filename": "Minister of State/ECC-4535-455 - redline - Minister of State.pdf",
+            "s3uripath": "https://citz-foi-prod.objectstore.gov.bc.ca/ecc-dev-e/ECC-4535-455/redline/Minister of State/ECC-4535-455 - redline - Minister of State.pdf"
+          }
+        ],
+        "includeduplicatepages": true,
+        "includenrpages": true,
+        "phase": null,
+        "includecomments": true,
+        "documentsetid": 158
+      }
+    ],
+    "requestnumber": "ECC-4535-455",
+    "bcgovcode": "ecc",
+    "summarydocuments": {
+      "sorteddocuments": [26586],
+      "pkgdocuments": [
+        {
+          "divisionid": 87,
+          "documentids": [26586]
+        }
+      ]
+    },
+    "redactionlayerid": 1,
+    "requesttype": "general"
+  }'
+```
+
+### Successful response
+
+```json
+{
+  "status": true,
+  "message": "Added to stream"
+}
+```
+
+### Failure modes
+
+| HTTP status | Scenario | Notes |
+| --- | --- | --- |
+| `400` | Malformed JSON or missing expected keys | Returned when a `KeyError` is raised in the resource. |
+| `500` | Business/service failure | For example, downstream stream publish failure or other business exception. |
+
+### Operational notes
+
+- This endpoint is asynchronous by design. A `200` response only confirms that the request was accepted and the stream publish succeeded.
+- The ZIP payload is assembled from the flattened set of all files in `attributes[*].files[*]`.
+- `summarydocuments`, `includecomments`, `includeduplicatepages`, `includenrpages`, `phase`, and `documentsetid` are forwarded for downstream processing; this route itself does not interpret those values beyond schema validation and message packaging.
+- The resource for this endpoint is implemented in `api/reviewer_api/resources/redaction.py`, and the service logic is in `api/reviewer_api/services/radactionservice.py`.

--- a/api/docs/ZIPPING_PROCESS.md
+++ b/api/docs/ZIPPING_PROCESS.md
@@ -1,0 +1,301 @@
+# Zipping Process
+
+## Purpose
+
+This document describes the current zipping flow used by the redline and final-package endpoints.
+
+It covers the active pipeline:
+
+1. API accepts the package request.
+2. Document service optionally generates summary PDFs.
+3. Document service forwards the package payload to the zipper stream.
+4. Zipping service downloads all source files from object storage, creates the ZIP, uploads the final archive, records package/job state, and emits completion notifications.
+
+This document intentionally focuses on the current `DocumentServices` -> `ZippingServices` path, not the older `PDFStitchServices` zipper producer flow.
+
+## End-to-End Flow
+
+1. The API receives `POST /api/triggerdownloadredline` or `POST /api/triggerdownloadfinalpackage`.
+2. The API creates a `PDFStitchJob` row and publishes a document-service stream message.
+3. `DocumentServices` consumes the message.
+4. `redactionsummaryservice` generates zero or more summary PDFs, depending on category.
+5. `DocumentServices` merges the original `filestozip` with any generated summary files.
+6. `DocumentServices` publishes the merged payload to the zipper Redis stream.
+7. `ZippingServices` consumes the zipper message.
+8. `ZippingServices` downloads each file referenced in `filestozip`.
+9. `ZippingServices` writes each file into a ZIP archive.
+10. The completed ZIP is uploaded to object storage.
+11. The final ZIP path is written to `PDFStitchPackage`.
+12. Completion or error notifications are emitted for redline and response-package flows.
+
+## Entry Points
+
+### API and document-service handoff
+
+- [radactionservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/services/radactionservice.py#L125) prepares the initial package message and flattens `attributes[*].files[*]` into `filestozip`.
+- [documentservicestreamreader.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/rstreamio/reader/documentservicestreamreader.py#L66) consumes the document-service stream message.
+- [zippingservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/zippingservice.py#L6) appends summary files and forwards the message to the zipper stream.
+- [zipperstreamwriter.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/rstreamio/writer/zipperstreamwriter.py#L5) writes the final zipper message.
+
+### Zipper consumer and worker
+
+- [foirediszipperconsumer.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/foirediszipperconsumer.py#L24) reads the zipper Redis stream.
+- [zipperservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperservice.py#L16) performs the actual ZIP creation and upload.
+- [zipperdboperations.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperdboperations.py#L6) records job status and final package location.
+- [notificationservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/notificationservice.py#L8) publishes completion notifications.
+
+## Message Contract
+
+The active zipper payload is represented by [zipperproducermessage.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/models/zipperproducermessage.py#L1).
+
+Important fields:
+
+| Field | Description |
+| --- | --- |
+| `jobid` | Primary job identifier used across `PDFStitchJob` versions. |
+| `category` | Determines package type, DB category normalization, and notification behavior. |
+| `requestnumber` | Used to build the final ZIP file path. |
+| `bcgovcode` | Used to resolve object-storage credentials and target bucket. |
+| `createdby` | Persisted in job/package rows and notifications. |
+| `ministryrequestid` | Request identifier used in DB writes and notifications. |
+| `filestozip` | JSON array of files to fetch and add to the ZIP. |
+| `attributes` | Original package metadata, persisted into job records. |
+| `feeoverridereason` | Forwarded to response-package notifications. |
+| `foldername` | Optional top-level folder name that overrides the default category-based ZIP path. |
+| `phase` | Used to normalize phase categories when saving final package records. |
+
+### `filestozip` shape
+
+`filestozip` is a JSON string containing objects like:
+
+```json
+[
+  {
+    "filename": "Minister of State/ECC-4535-455 - redline - Minister of State.pdf",
+    "s3uripath": "https://.../ECC-4535-455/redline/Minister of State/ECC-4535-455 - redline - Minister of State.pdf"
+  },
+  {
+    "filename": "Minister of State/ECC-4535-455 - Redline - summary.pdf",
+    "s3uripath": "https://.../ECC-4535-455/redline/Minister of State/ECC-4535-455 - Redline - summary.pdf"
+  }
+]
+```
+
+`filename` becomes the internal ZIP entry path. If it includes path separators, the resulting ZIP preserves that folder structure.
+
+## How Files Reach the Zipper
+
+The zipper never assembles source files itself. It consumes a prepared file list.
+
+### Original package files
+
+The API builds `filestozip` by flattening `attributes[*].files[*]`.
+
+Reference: [radactionservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/api/reviewer_api/services/radactionservice.py#L174)
+
+### Summary files
+
+If summary generation runs successfully, `DocumentServices` appends the generated summary files to the original `filestozip` before publishing to the zipper stream.
+
+Reference: [DocumentServices zippingservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/DocumentServices/services/zippingservice.py#L11)
+
+That means the zipper operates on the final complete file list:
+
+- Stitched package PDFs already uploaded to object storage.
+- Generated summary PDFs, when applicable.
+
+## Stream Consumption Model
+
+`foirediszipperconsumer.py` uses a simple stream-reader model:
+
+- Reads from the configured zipper stream.
+- Tracks the last processed message ID per consumer in Redis.
+- Decodes each message from bytes to strings.
+- Converts the JSON payload into a `zipperproducermessage`.
+- Calls `processmessage(...)`.
+- Calls `sendnotification(...)` after processing.
+- Deletes the stream message after handling it.
+
+Reference: [foirediszipperconsumer.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/foirediszipperconsumer.py#L24)
+
+This consumer does not use Redis consumer groups; it persists a last-seen stream ID instead.
+
+## ZIP Creation Logic
+
+The active ZIP creation logic lives in [zipperservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperservice.py#L16).
+
+### Processing stages
+
+1. Resolve S3 credentials from `bcgovcode`.
+2. Record zipper job start in `PDFStitchJob` with status `zippingstarted`.
+3. Parse `filestozip`.
+4. Download each source file from object storage.
+5. For PDFs, rebuild the document through `PyPDF2` to strip metadata and other sensitive content.
+6. Write each file into a temporary ZIP archive using `ZIP_DEFLATED` with `compresslevel=9`.
+7. Upload the final ZIP to object storage.
+8. Record zipper completion in `PDFStitchJob`.
+9. Save the final uploaded path in `PDFStitchPackage`.
+10. Record final job completion or error state.
+
+### PDF sanitization
+
+For `.pdf` sources, the zipper runs the bytes through `__removesensitivecontent(...)`, which:
+
+- Reads the PDF with `PyPDF2.PdfReader`
+- Copies pages into a new `PdfWriter`
+- Writes a new PDF byte stream without preserving metadata
+
+If sanitization fails for a file, the service logs the exception and falls back to the original file bytes for that ZIP entry.
+
+Reference: [zipperservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperservice.py#L91)
+
+## Object Storage Reads and Writes
+
+The zipper service fetches both source files and upload credentials dynamically.
+
+### Credential lookup
+
+`getcredentialsbybcgovcode(...)` queries `DocumentPathMapper` for the bucket `{bcgovcode}-{env}-e` and category `Records`.
+
+Reference: [s3documentservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/s3documentservice.py#L10)
+
+### Source-file download
+
+Each `s3uripath` in `filestozip` is fetched with an AWS-signed `GET` request.
+
+Reference: [s3documentservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/s3documentservice.py#L28)
+
+### ZIP upload
+
+The final ZIP is uploaded to:
+
+```text
+https://{s3_host}/{bcgovcode}-{env}-e/{requestnumber}/{zip-path}
+```
+
+Reference: [s3documentservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/s3documentservice.py#L50)
+
+## Final ZIP Naming
+
+ZIP naming is handled by `__getzipfilepath(...)` in [zipperservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperservice.py#L178).
+
+Rules:
+
+- If `foldername` is set, ZIP path is `{FoldernameCapitalized}/{requestnumber}.zip`
+- Otherwise, ZIP path is `{CategoryCapitalized}/{requestnumber}.zip`
+
+Examples:
+
+- `Redline/ECC-4535-455.zip`
+- `Responsepackage/ECC-4535-455.zip`
+
+The uploaded object key always sits under `{requestnumber}/...` in the target bucket.
+
+## Database Writes
+
+The zipper process writes to two main tables.
+
+### `PDFStitchJob`
+
+`recordjobstatus(...)` inserts new versions of the same `pdfstitchjobid`.
+
+For zipper processing, categories are normalized as:
+
+- `redline-zipper`
+- `responsepackage-zipper`
+- `oipcredline-zipper`
+- `openinfo-zipper`
+- Phase categories collapse to `redline-zipper` or `responsepackage-zipper`
+
+Observed statuses:
+
+- `zippingstarted` at version `3`
+- `zippingcompleted` at version `4`
+- `completed` or `error` at version `5`
+
+Reference: [zipperdboperations.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperdboperations.py#L26)
+
+### `PDFStitchPackage`
+
+After a successful upload, `savefinaldocumentpath(...)` stores:
+
+- `ministryrequestid`
+- normalized `category`
+- final ZIP `documentpath`
+- `createdby`
+
+Reference: [zipperdboperations.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperdboperations.py#L6)
+
+## Category Normalization
+
+Two separate normalization rules matter in the zipper flow.
+
+### Job-status normalization
+
+`assigncategory(...)` collapses phase variants:
+
+- any `redline_phase...` becomes `redline`
+- any `responsepackage_phase...` becomes `responsepackage`
+
+This affects `PDFStitchJob` category values.
+
+### Final-package normalization
+
+Before saving `PDFStitchPackage`, `zipperservice.processmessage(...)` removes underscores from phase categories:
+
+- `redline_phase2` becomes `redlinephase2`
+- `responsepackage_phase1` becomes `responsepackagephase1`
+
+Reference: [zipperservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/zipperservice.py#L35)
+
+## Notifications
+
+After processing, the consumer calls `sendnotification(...)`.
+
+### Redline and response package
+
+For these categories, notifications are emitted only after zipper completion has been confirmed through `isredlineresponsezipjobcompleted(...)`.
+
+Service IDs:
+
+- `pdfstitchforredline`
+- `pdfstitchforresponsepackage`
+
+For response-package notifications, `feeoverridereason` is included when present.
+
+Reference: [notificationservice.py](/home/alvesfc/workspace/bcgov/sync/foi-docreviewer/computingservices/ZippingServices/services/notificationservice.py#L24)
+
+### Harms
+
+The zipper service also supports harms notifications, but that is a different package flow and not the primary path used by the current redline/final-package endpoints.
+
+## Error Handling
+
+The zipper worker records errors at the job layer and does not silently ignore failures.
+
+Important behavior:
+
+- Any top-level exception in `processmessage(...)` results in version `5` status `error`.
+- Upload failure also results in final `error` status.
+- Individual PDF metadata-scrubbing failures do not fail the whole ZIP; the original bytes are used instead.
+- S3 `GET` and `PUT` operations retry according to configured retry counts in the zipper service config.
+
+## Operational Characteristics
+
+- The ZIP is built in a temporary spooled file, not streamed directly from source to destination.
+- Compression uses `ZIP_DEFLATED` with `compresslevel=9`.
+- `allowZip64=True` is enabled, so large ZIPs are supported.
+- The zipper expects every `filestozip[*].s3uripath` object to already exist and be readable with the resolved ministry credentials.
+- Internal ZIP structure is entirely controlled by `filestozip[*].filename`.
+
+## Practical Example
+
+For a redline request:
+
+1. The API produces `filestozip` from redline PDF paths uploaded by the frontend.
+2. The document service adds `... - summary.pdf` files.
+3. The zipper downloads each referenced PDF.
+4. The zipper creates `Redline/{requestnumber}.zip`.
+5. The zipper uploads the archive to object storage under `{requestnumber}/Redline/{requestnumber}.zip`.
+6. The final path is persisted in `PDFStitchPackage`.
+7. A `pdfstitchforredline` notification is emitted.


### PR DESCRIPTION
Adds multiple API documentation files covering:
- redline download trigger and payload structure
- summary generation process
- zipping workflow for final packages
- handling of deleted files and pages