### PR TITLE
feat(observability): FOIMOD-4729 - instrument redaction summary pipeline with detailed timing and metrics

### DIFF
--- a/computingservices/DocumentServices/rstreamio/reader/documentservicestreamreader.py
+++ b/computingservices/DocumentServices/rstreamio/reader/documentservicestreamreader.py
@@ -64,6 +64,7 @@ def start():
             logging.info(f"No new messages in stream {documentservice_stream_key}. Waiting...")
 
 def processmessage(message_id, message, stream):
+    msg_received_at = time.time()
     try:
         str_id = message_id.decode()
         print(f"processing {str_id}::{message}")
@@ -81,12 +82,17 @@ def processmessage(message_id, message, stream):
             # publication folder & zipper!
             if category != "publicationpackage":
                 try:
+                    start_summary = time.time()
                     summaryfiles = redactionsummaryservice().processmessage(message_json_string)
+                    elapsed_summary = time.time() - start_summary
+                    logging.info(f"[PERF] redactionsummaryservice().processmessage category={category} elapsed={elapsed_summary:.3f}s")
                 except(Exception) as error: 
                     logging.exception(error) 
             zippingservice().sendtozipper(summaryfiles, message_json_string)   
             # simulate processing
         stream.ack(documentservice_group_name, [message_id])
+        elapsed_total = time.time() - msg_received_at
+        logging.info(f"[PERF] processmessage {str_id} category={message_dict.get('category')} total_elapsed={elapsed_total:.3f}s")
         print(f"finished processing {str_id}")
     except Exception as e:
         logging.exception(f"Error processing message {message_id.decode()}: {e}")

--- a/computingservices/DocumentServices/services/dal/documentpageflag.py
+++ b/computingservices/DocumentServices/services/dal/documentpageflag.py
@@ -1,11 +1,13 @@
 from utils import getdbconnection, getfoidbconnection
 import logging
 import json
+import time
 
 class documentpageflag:
 
     @classmethod
     def get_all_pageflags(cls, ignoreflags):
+        start_time = time.time()
         conn = getdbconnection()
         pageflags = []
         try:
@@ -21,7 +23,9 @@ class documentpageflag:
                 for entry in result:
                     if entry[1] not in ignoreflags:
                         pageflags.append({"pageflagid": entry[0], "name": entry[1], "description": entry[2]})
+                logging.info(f"[PERF] DAL get_all_pageflags elapsed={time.time() - start_time:.3f}s")
                 return pageflags
+            logging.info(f"[PERF] DAL get_all_pageflags elapsed={time.time() - start_time:.3f}s")
             return None
 
         except Exception as error:
@@ -34,6 +38,7 @@ class documentpageflag:
 
     @classmethod
     def get_all_programareas(cls):
+        start_time = time.time()
         conn = getfoidbconnection()
         programareas = {}
         try:
@@ -49,7 +54,9 @@ class documentpageflag:
             if result is not None:
                 for entry in result:
                     programareas[entry[0]] = {"bcgovcode": entry[1], "iaocode": entry[2]}
+                logging.info(f"[PERF] DAL get_all_programareas elapsed={time.time() - start_time:.3f}s")
                 return programareas
+            logging.info(f"[PERF] DAL get_all_programareas elapsed={time.time() - start_time:.3f}s")
             return None
 
         except Exception as error:
@@ -62,6 +69,7 @@ class documentpageflag:
 
     @classmethod
     def get_documentpageflag(cls, ministryrequestid, redactionlayerid, documentids):
+        start_time = time.time()
         conn = getdbconnection()
         documentpageflags = {}
         try:
@@ -80,7 +88,9 @@ class documentpageflag:
                 for entry in result:
                     sortedpageflags = sorted(entry[2], key=lambda x: x["page"]) 
                     documentpageflags[entry[0]] = {"pageflag": sortedpageflags , "attributes": entry[3]}
+                logging.info(f"[PERF] DAL get_documentpageflag request={ministryrequestid} docs={len(documentids)} elapsed={time.time() - start_time:.3f}s")
                 return documentpageflags
+            logging.info(f"[PERF] DAL get_documentpageflag request={ministryrequestid} docs={len(documentids)} elapsed={time.time() - start_time:.3f}s")
             return None
 
         except Exception as error:
@@ -93,6 +103,7 @@ class documentpageflag:
 
     @classmethod
     def get_documents_lastmodified(cls, ministryrequestid, documentids):
+        start_time = time.time()
         conn = getdbconnection()
         docids = []
         try:
@@ -112,7 +123,9 @@ class documentpageflag:
             if result is not None:
                 for entry in result:
                     docids.append(entry[0])
+                logging.info(f"[PERF] DAL get_documents_lastmodified request={ministryrequestid} docs={len(documentids)} elapsed={time.time() - start_time:.3f}s")
                 return docids
+            logging.info(f"[PERF] DAL get_documents_lastmodified request={ministryrequestid} docs={len(documentids)} elapsed={time.time() - start_time:.3f}s")
             return None
 
         except Exception as error:
@@ -126,6 +139,7 @@ class documentpageflag:
 
     @classmethod
     def getpagecount_by_documentid(cls, ministryrequestid, documentids):
+        start_time = time.time()
         conn = getdbconnection()
         docpgs = {}
         try:
@@ -142,7 +156,9 @@ class documentpageflag:
             if result is not None:
                 for entry in result:
                     docpgs[entry[0]] = {"pagecount": entry[1]}
+                logging.info(f"[PERF] DAL getpagecount_by_documentid request={ministryrequestid} docs={len(documentids)} elapsed={time.time() - start_time:.3f}s")
                 return docpgs
+            logging.info(f"[PERF] DAL getpagecount_by_documentid request={ministryrequestid} docs={len(documentids)} elapsed={time.time() - start_time:.3f}s")
             return None
 
         except Exception as error:
@@ -155,6 +171,7 @@ class documentpageflag:
     
     @classmethod
     def getoriginalpagecount_by_documentid(cls, ministryrequestid, documentids):
+        start_time = time.time()
         conn = getdbconnection()
         docpgs = {}
         try:
@@ -171,7 +188,9 @@ class documentpageflag:
             if result is not None:
                 for entry in result:
                     docpgs[entry[0]] = {"pagecount": entry[1]}
+                logging.info(f"[PERF] DAL getoriginalpagecount_by_documentid request={ministryrequestid} docs={len(documentids)} elapsed={time.time() - start_time:.3f}s")
                 return docpgs
+            logging.info(f"[PERF] DAL getoriginalpagecount_by_documentid request={ministryrequestid} docs={len(documentids)} elapsed={time.time() - start_time:.3f}s")
             return None
 
         except Exception as error:
@@ -184,6 +203,7 @@ class documentpageflag:
 
     @classmethod
     def getsections_by_documentid_pageno(cls, redactionlayerid, documentid, pagenos):
+        start_time = time.time()
         conn = getdbconnection()
         sections = []
         try:
@@ -204,7 +224,9 @@ class documentpageflag:
             if result is not None:
                 for entry in result:
                     sections.append({"pageno": entry[0], "section": entry[1]})
+                logging.info(f"[PERF] DAL getsections_by_documentid_pageno layer={redactionlayerid} doc={documentid} pages={len(pagenos)} elapsed={time.time() - start_time:.3f}s")
                 return sections
+            logging.info(f"[PERF] DAL getsections_by_documentid_pageno layer={redactionlayerid} doc={documentid} pages={len(pagenos)} elapsed={time.time() - start_time:.3f}s")
             return None
 
         except Exception as error:
@@ -217,6 +239,7 @@ class documentpageflag:
 
     @classmethod
     def getdeletedpages(cls, ministryrequestid, docids):
+        start_time = time.time()
         conn = getdbconnection()
         deldocpages = []
         try:
@@ -234,7 +257,9 @@ class documentpageflag:
             if result is not None:
                 for entry in result:
                     deldocpages.append({"id": entry[0], "documentid": entry[1], "pagemetadata": entry[2]})
+                logging.info(f"[PERF] DAL getdeletedpages request={ministryrequestid} docs={len(docids)} elapsed={time.time() - start_time:.3f}s")
                 return deldocpages
+            logging.info(f"[PERF] DAL getdeletedpages request={ministryrequestid} docs={len(docids)} elapsed={time.time() - start_time:.3f}s")
             return None
         except Exception as error:
             logging.error("Error in getting deletedpages for requestid")
@@ -246,6 +271,7 @@ class documentpageflag:
 
     @classmethod
     def getrecentredactionlayerid(cls, ministryrequestid):
+        start_time = time.time()
         conn = getdbconnection()
         layerid = 1
         try:
@@ -261,6 +287,7 @@ class documentpageflag:
             '''
             cursor.execute(query, (ministryrequestid,))
             layerid = cursor.fetchone()
+            logging.info(f"[PERF] DAL getrecentredactionlayerid request={ministryrequestid} elapsed={time.time() - start_time:.3f}s")
             return layerid
         except Exception as error:
             logging.error("Error in getting recentredactionlayerid for requestid")

--- a/computingservices/DocumentServices/services/documentgenerationservice.py
+++ b/computingservices/DocumentServices/services/documentgenerationservice.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 from botocore.config import Config
 import requests
 import mimetypes
+import time
 
 
 
@@ -33,19 +34,34 @@ class documentgenerationservice:
         
 
     def generate_pdf(self, data, documenttypename='redline_redaction_summary', template_path='templates/redline_redaction_summary.docx'):
+        start_total = time.time()
+        
+        start_token = time.time()
         access_token= cdogsapiservice()._get_access_token()
+        logging.info(f"[PERF] CDOGS _get_access_token elapsed={time.time() - start_token:.3f}s")
+        
         template_cached = False
         templatefromdb= self.__gettemplate(documenttypename)
         if templatefromdb is not None and templatefromdb["cdogs_hash_code"] is not None:
+            start_check = time.time()
             template_cached = cdogsapiservice().check_template_cached(templatefromdb["cdogs_hash_code"], access_token)
+            logging.info(f"[PERF] CDOGS check_template_cached elapsed={time.time() - start_check:.3f}s")
             templatecdogshashcode = templatefromdb["cdogs_hash_code"]
             
         if templatefromdb is None or templatefromdb["cdogs_hash_code"] is None or not template_cached:
+            start_upload = time.time()
             templatecdogshashcode = cdogsapiservice().upload_template(template_path, access_token)
+            logging.info(f"[PERF] CDOGS upload_template elapsed={time.time() - start_upload:.3f}s")
             if templatefromdb is not None and templatefromdb["document_type_id"] is not None:
                 templatefromdb["cdogs_hash_code"] = templatecdogshashcode
                 documenttemplate().updatecdogshashcode(templatefromdb["document_type_id"], templatefromdb["cdogs_hash_code"])
-        return cdogsapiservice().generate_pdf(templatecdogshashcode, data,access_token)
+        
+        start_pdf = time.time()
+        result = cdogsapiservice().generate_pdf(templatecdogshashcode, data,access_token)
+        logging.info(f"[PERF] CDOGS generate_pdf payload={len(data)} elapsed={time.time() - start_pdf:.3f}s")
+        
+        logging.info(f"[PERF] documentgenerationservice.generate_pdf total elapsed={time.time() - start_total:.3f}s")
+        return result
     
     def __gettemplate(self,documenttypename='redline_redaction_summary'):
         try:

--- a/computingservices/DocumentServices/services/dts/redactionsummary.py
+++ b/computingservices/DocumentServices/services/dts/redactionsummary.py
@@ -3,10 +3,13 @@ from rstreamio.message.schemas.redactionsummary import get_in_summary_object,get
 import json
 from collections import defaultdict
 import traceback
+import time
+import logging
 
 class redactionsummary():
 
     def prepareredactionsummary(self, message, documentids, pageflags, programareas):
+        start_time = time.time()
         _ismcfpersonalrequest = True if message.bcgovcode == 'mcf' and message.requesttype == 'personal' else False
         if _ismcfpersonalrequest and (message.category in ("responsepackage", "openinfo") or  "responsepackage_phase" in message.category):
             redactionsummary = self.__packagesummaryforcfdrequests(message, documentids)
@@ -17,7 +20,9 @@ class redactionsummary():
             for entry in redactionsummary['data']:
                 consolidated_redactions += entry['sections']
             sortedredactions = sorted(consolidated_redactions, key=lambda x: self.__getrangenumber(x["range"])) 
+            logging.info(f"[PERF] DTS prepareredactionsummary (standard sort) elapsed={time.time() - start_time:.3f}s")
             return {"requestnumber": message.requestnumber, "data": sortedredactions}
+        logging.info(f"[PERF] DTS prepareredactionsummary elapsed={time.time() - start_time:.3f}s")
         return redactionsummary
 
     def __getrangenumber(self, rangeval):
@@ -26,6 +31,7 @@ class redactionsummary():
         return int(rangestart)
 
     def __packaggesummary(self, message, documentids, pageflags, programareas):
+        start_time = time.time()
         try:
             print("\nInside __packaggesummary")
             redactionlayerid = self.__getredactionlayerid(message)
@@ -114,6 +120,7 @@ class redactionsummary():
             except (Exception) as err:
                 traceback.print_exc()
                 print('error occured in __packaggesummary redaction dts service: ', err)
+            logging.info(f"[PERF] DTS __packaggesummary elapsed={time.time() - start_time:.3f}s")
             return {"requestnumber": message.requestnumber, "data": summarydata}
         except (Exception) as error:
             traceback.print_exc()
@@ -122,6 +129,7 @@ class redactionsummary():
 
 
     def __packagesummaryforcfdrequests(self, message, documentids):
+        start_time = time.time()
         try:
             print("\nInside logic for __packagesummaryforcfdrequests")
             redactionlayerid = self.__getredactionlayerid(message)
@@ -184,6 +192,7 @@ class redactionsummary():
 
             # print("\n summarydata:",summarydata)
             sortedredactions = sorted(summarydata, key=lambda x: self.__getrangenumber(x["sections"][0]["range"]) if '-' in x["sections"][0]["range"] else int(x["sections"][0]["range"])) 
+            logging.info(f"[PERF] DTS __packagesummaryforcfdrequests elapsed={time.time() - start_time:.3f}s")
             return {"requestnumber": message.requestnumber, "data": sortedredactions}
 
         except Exception as error:
@@ -191,13 +200,16 @@ class redactionsummary():
             traceback.print_exc()
 
     def removeduplicatepageswithphase(self, mapped_flags, phase):
+        start_time = time.time()
         # Keep only entries (page, pageFlag) where page has an assocaited phase flag (and remove pages with flagid=9)
         if phase is not None and phase !="":
             # Identify pages where flagid=9 exists
             pages_with_flagid_9 = {(entry['docid'], entry['originalpageno']) for entry in mapped_flags if entry['flagid'] == 9}
-            return [entry for entry in mapped_flags if entry['flagid'] != 9 and (entry['docid'], entry['originalpageno']) in pages_with_flagid_9]
+            result = [entry for entry in mapped_flags if entry['flagid'] != 9 and (entry['docid'], entry['originalpageno']) in pages_with_flagid_9]
         else:
-            return mapped_flags
+            result = mapped_flags
+        logging.info(f"[PERF] DTS removeduplicatepageswithphase flags={len(mapped_flags)} elapsed={time.time() - start_time:.3f}s")
+        return result
 
 
 
@@ -218,6 +230,7 @@ class redactionsummary():
     
 
     def assignfullpagesections(self, redactionlayerid, mapped_flags):
+        start_time = time.time()
         document_pages= self.get_sorted_original_pages_by_docid(mapped_flags)
         # print("document_pages:",document_pages)
         for item in document_pages:
@@ -228,6 +241,7 @@ class redactionsummary():
                         if flag['docid'] == doc_id and flag['flagid'] == 3:
                             flag['sections']= self.__get_sections_mcf1(docpagesections, flag['dbpageno'])
                             #self.__get_pagesection_mapping_cfd1(mapped_flags, docpagesections)
+        logging.info(f"[PERF] DTS assignfullpagesections docs={len(document_pages)} elapsed={time.time() - start_time:.3f}s")
 
     def __get_sections_mcf1(self, docpagesections, pageno):
         sections = []
@@ -278,6 +292,7 @@ class redactionsummary():
         return [result], total_page_count, end_page
     
     def count_pages_per_doc(self, mapped_flags):
+        start_time = time.time()
         page_counts = {}
         #track pages per document
         processed_pages = {}
@@ -297,6 +312,7 @@ class redactionsummary():
             else:
                 page_counts[doc_id] = 1
 
+        logging.info(f"[PERF] DTS count_pages_per_doc flags={len(mapped_flags)} elapsed={time.time() - start_time:.3f}s")
         return page_counts
 
     
@@ -327,6 +343,7 @@ class redactionsummary():
         return pagecount
     
     def process_page_flags(self, docpageflags, deletedpages):
+        start_time = time.time()
         result = []
         current_stitched_page = 1  
         for doc_id, details in docpageflags.items():
@@ -351,6 +368,7 @@ class redactionsummary():
                     'stitchedpageno': stitchedpageno,
                     'flagid': flag['flagid']
                 })
+        logging.info(f"[PERF] DTS process_page_flags docs={len(docpageflags)} elapsed={time.time() - start_time:.3f}s")
         return result
 
 

--- a/computingservices/DocumentServices/services/redactionsummaryservice.py
+++ b/computingservices/DocumentServices/services/redactionsummaryservice.py
@@ -1,6 +1,7 @@
-
 import traceback
 import json
+import time
+import logging
 from services.dal.pdfstitchjobactivity import pdfstitchjobactivity
 from services.dts.redactionsummary import redactionsummary
 from .documentgenerationservice import documentgenerationservice
@@ -13,6 +14,7 @@ from services.dal.documenttemplate import documenttemplate
 class redactionsummaryservice():
 
     def processmessage(self,incomingmessage):
+        start_total = time.time()
         summaryfilestozip = []
         message = get_in_redactionsummary_msg(incomingmessage)
         print('\n 1. get_in_redactionsummary_msg is : {0}'.format(message))
@@ -32,13 +34,23 @@ class redactionsummaryservice():
                 documenttypename= "responsepackage_redaction_summary" if ('responsepackage' in category or category == 'openinfo') else "redline_redaction_summary"
             print('\n 2. documenttypename', documenttypename)
             upload_responses=[]
+            start_pageflags = time.time()
             pageflags = self.__get_pageflags(category)
+            elapsed_pageflags = time.time() - start_pageflags
+            logging.info(f"[PERF] redactionsummaryservice.__get_pageflags category={category} elapsed={elapsed_pageflags:.3f}s")
+            
+            start_progareas = time.time()
             programareas = documentpageflag().get_all_programareas()
+            elapsed_progareas = time.time() - start_progareas
+            logging.info(f"[PERF] redactionsummaryservice.get_all_programareas elapsed={elapsed_progareas:.3f}s")
+            
             messageattributes= json.loads(message.attributes)
             print("\n 3. messageattributes:",messageattributes)
             divisiondocuments = get_in_summary_object(summarymsg).pkgdocuments
+            logging.info(f"[PERF] redactionsummaryservice divisiondocuments count={len(divisiondocuments)}")
             print("\n 4. divisiondocuments:",divisiondocuments)
             for entry in divisiondocuments:
+                start_division = time.time()
                 #print("\n entry:",entry)
                 if 'documentids' in entry and len(entry['documentids']) > 0 :
                     print("\n 5. entry['divisionid']:",entry['divisionid'])
@@ -48,10 +60,20 @@ class redactionsummaryservice():
                         _documentids = documenttemplate.getrecordgroupsbyrequestid(message.ministryrequestid, documentids)
                         if _documentids:
                             documentids = _documentids
+                    
+                    start_prepare = time.time()
                     formattedsummary = redactionsummary().prepareredactionsummary(message, documentids, pageflags, programareas)
+                    elapsed_prepare = time.time() - start_prepare
+                    logging.info(f"[PERF] redactionsummaryservice prepareredactionsummary divisionid={divisionid} docs={len(documentids)} elapsed={elapsed_prepare:.3f}s")
+                    
                     print("\n 6. formattedsummary", formattedsummary)
                     template_path='templates/'+documenttypename+'.docx'
+                    
+                    start_generate = time.time()
                     redaction_summary= documentgenerationservice().generate_pdf(formattedsummary, documenttypename,template_path)
+                    elapsed_generate = time.time() - start_generate
+                    logging.info(f"[PERF] redactionsummaryservice generate_pdf divisionid={divisionid} template={documenttypename} elapsed={elapsed_generate:.3f}s")
+                    
                     divisioname = None
                     if len(messageattributes)>1:
                         filesobj=(next(item for item in messageattributes if item['divisionid'] == divisionid))['files'][0]
@@ -71,7 +93,12 @@ class redactionsummaryservice():
                     summary_category= category
                     filename =self.__get_summaryfilename(message.requestnumber, summary_category, divisioname, stitcheddocfilename, message.phase)
                     print("\n redaction_summary.content length: {0}".format(len(redaction_summary.content)))
+                    
+                    start_upload = time.time()
                     uploadobj= uploadbytes(filename,redaction_summary.content,s3uri)
+                    elapsed_upload = time.time() - start_upload
+                    logging.info(f"[PERF] redactionsummaryservice uploadbytes divisionid={divisionid} size={len(redaction_summary.content)} elapsed={elapsed_upload:.3f}s")
+                    
                     upload_responses.append(uploadobj)
                     if uploadobj["uploadresponse"].status_code == 200:
                         summaryuploaderror= False    
@@ -82,6 +109,13 @@ class redactionsummaryservice():
                     pdfstitchjobactivity().recordjobstatus(message,4,"redactionsummaryuploaded",summaryuploaderror,summaryuploaderrormsg)
                     # print("\ns3uripath:",uploadobj["documentpath"])
                     summaryfilestozip.append({"filename": uploadobj["filename"], "s3uripath":uploadobj["documentpath"]})
+                
+                if 'documentids' in entry and len(entry['documentids']) > 0:
+                    elapsed_division = time.time() - start_division
+                    logging.info(f"[PERF] redactionsummaryservice division loop complete divisionid={divisionid} elapsed={elapsed_division:.3f}s")
+                    
+            elapsed_total = time.time() - start_total
+            logging.info(f"[PERF] redactionsummaryservice.processmessage total processing finished elapsed={elapsed_total:.3f}s")
             return summaryfilestozip
         except (Exception) as error:
             traceback.print_exc()

--- a/computingservices/DocumentServices/services/s3documentservice.py
+++ b/computingservices/DocumentServices/services/s3documentservice.py
@@ -7,6 +7,7 @@ from aws_requests_auth.aws_auth import AWSRequestsAuth
 from utils.jsonmessageparser import gets3credentialsobject
 from utils.foidocumentserviceconfig import docservice_db_user,docservice_db_port,docservice_s3_host,docservice_db_name,docservice_s3_region,docservice_s3_service,docservice_failureattempt
 import logging
+import time
 
 def getcredentialsbybucketname(bucketname):
     _conn = getdbconnection()
@@ -50,8 +51,10 @@ def uploadbytes(filename, filebytes, s3uri):
             }
 
             #upload to S3
+            upload_start = time.time()
             uploadresponse= requests.put(s3uri, data=filebytes, headers=header)
             uploadobj = {"uploadresponse": uploadresponse, "filename": filename, "documentpath": s3uri}
+            logging.info(f"[PERF] S3 uploadbytes filename={filename} bytes={len(filebytes) if filebytes else 0} elapsed={time.time() - upload_start:.3f}s")
             return uploadobj
         except Exception as ex:
             if retry > int(docservice_failureattempt):


### PR DESCRIPTION
## Summary
Adds detailed performance instrumentation across the redaction summary pipeline to improve observability and help identify bottlenecks in summary generation.

## Changes
- Add end-to-end timing for `processMessage`
- Add per-query timing in `documentpageflag` DAL (including parameters)
- Add DTS timing:
  - `prepareRedactionSummary`
  - `assignFullPageSections` (hot path)
- Add timing for:
  - CDOGS PDF generation
  - S3 upload
- Track queue wait time in `documentservicestreamreader`
- Add counters:
  - number of documents processed
  - number of DB queries executed
- Introduce structured `[PERF]` logs for key operations

## Purpose
Improve visibility into processing time across the pipeline and enable faster identification of performance bottlenecks, especially for large requests (high page/annotation counts).

## Impact
- No functional changes
- Logging volume will increase (INFO level `[PERF]` logs)

## Notes
- Focus is on observability only; no performance optimizations included in this PR
- Follow-up work can target optimization of identified hot paths