### PR TITLE
Adds normalized Apryse annotation type metadata 

### DIFF
--- a/api/migrations/versions/2b4c7d6e8f90_add_annotation_type.py
+++ b/api/migrations/versions/2b4c7d6e8f90_add_annotation_type.py
@@ -1,0 +1,27 @@
+"""add annotation type
+
+Revision ID: 2b4c7d6e8f90
+Revises: 81eb14daaace
+Create Date: 2026-05-13 11:35:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2b4c7d6e8f90'
+down_revision = '81eb14daaace'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "Annotations",
+        sa.Column("annotationtype", sa.String(length=40), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("Annotations", "annotationtype")

--- a/api/migrations/versions/3c5d8e7f9012_backfill_annotation_type.py
+++ b/api/migrations/versions/3c5d8e7f9012_backfill_annotation_type.py
@@ -1,0 +1,33 @@
+"""backfill annotation type
+
+Revision ID: 3c5d8e7f9012
+Revises: 2b4c7d6e8f90
+Create Date: 2026-05-13 11:37:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '3c5d8e7f9012'
+down_revision = '2b4c7d6e8f90'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE public."Annotations"
+        SET annotationtype = lower(
+            substring(
+                annotation FROM '^\\s*(?:<\\?xml[^>]*\\?>\\s*)?<([A-Za-z_][A-Za-z0-9_.:-]*)[\\s>/]'
+            )
+        )
+        WHERE annotationtype IS NULL;
+        """
+    )
+
+
+def downgrade():
+    op.execute('UPDATE public."Annotations" SET annotationtype = NULL;')

--- a/api/migrations/versions/4d6e9f801234_index_annotation_type.py
+++ b/api/migrations/versions/4d6e9f801234_index_annotation_type.py
@@ -1,0 +1,34 @@
+"""index annotation type
+
+Revision ID: 4d6e9f801234
+Revises: 3c5d8e7f9012
+Create Date: 2026-05-13 11:38:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '4d6e9f801234'
+down_revision = '3c5d8e7f9012'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS '
+            'idx_annotations_active_type_layer_doc_page '
+            'ON public."Annotations" '
+            '(annotationtype, redactionlayerid, documentid, documentversion, pagenumber) '
+            'WHERE isactive = TRUE'
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            'DROP INDEX CONCURRENTLY IF EXISTS '
+            'public.idx_annotations_active_type_layer_doc_page'
+        )

--- a/api/reviewer_api/models/AnnotationSections.py
+++ b/api/reviewer_api/models/AnnotationSections.py
@@ -409,37 +409,9 @@ class AnnotationSection(db.Model):
                 JOIN public."DocumentMaster" dm ON dm.documentmasterid = d.documentmasterid 
                     AND dm.ministryrequestid = :ministryrequestid
                 LEFT JOIN non_deleted_files vd ON dm.filepath ILIKE vd.filepath || '%'
-                WHERE a.annotation LIKE '%%freetext%%'
+                WHERE a.annotationtype = 'freetext'
                     AND a.redactionlayerid = :redactionlayerid
                     AND a.isactive = TRUE;
-            """
-            """
-                select unnest(xpath('//contents/text()', annotation::xml))::text as section 
-                   from "Annotations" a 
-                        join public."Documents" d on d.documentid = a.documentid and d.foiministryrequestid = :ministryrequestid
-                        join public."DocumentMaster" dm on dm.documentmasterid = d.documentmasterid and dm.ministryrequestid = :ministryrequestid
-                        left join public."DocumentDeleted" dd on dm.filepath ilike dd.filepath || '%' and dd.ministryrequestid = :ministryrequestid
-                        where a.annotation like '%%freetext%%'
-                        and a.redactionlayerid = :redactionlayerid
-                        and (dd.deleted is null or dd.deleted is false)
-                        and a.isactive = true;
-
-            """
-            """
-            sql = select section from public."Sections" where sectionid in
-                        (select distinct (json_array_elements((as1.section::json->>'ids')::json)->>'id')::integer
-                        from public."AnnotationSections" as1
-                        join public."Annotations" a on a.annotationname = as1.annotationname
-                        join public."Documents" d on d.documentid = a.documentid and d.foiministryrequestid = :ministryrequestid
-                        join public."DocumentMaster" dm on dm.documentmasterid = d.documentmasterid and dm.ministryrequestid = :ministryrequestid
-                        left join public."DocumentDeleted" dd on dm.filepath ilike dd.filepath || '%' and dd.ministryrequestid = :ministryrequestid
-                        where as1.foiministryrequestid = :ministryrequestid and as1.isactive  = true
-                        and as1.redactionlayerid = a.redactionlayerid 
-                        and as1.redactionlayerid = :redactionlayerid
-                        and (dd.deleted is null or dd.deleted is false)
-                        and a.isactive = true)
-                     and sectionid != 25
-                     order by sortorder
             """
             rs = db.session.execute(text(sql), {"ministryrequestid": ministryrequestid, "redactionlayerid": redactionlayerid})
             sections = []

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -10,6 +10,21 @@ from reviewer_api.utils.util import split, getbatchconfig
 from .Documents import Document
 from .DocumentMaster import DocumentMaster
 from .DocumentDeleted import DocumentDeleted
+import re
+
+
+_ANNOTATION_TYPE_PATTERN = re.compile(
+    r'^\s*(?:<\?xml[^>]*\?>\s*)?<([A-Za-z_][A-Za-z0-9_.:-]*)(?:\s|/|>)'
+)
+
+
+def get_annotation_type(annotation_xml):
+    if not annotation_xml:
+        return None
+    match = _ANNOTATION_TYPE_PATTERN.search(annotation_xml)
+    if match is None:
+        return None
+    return match.group(1).split(":")[-1].lower()
 
 
 class Annotation(db.Model):

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -236,7 +236,7 @@ class Annotation(db.Model):
                         Annotation.isactive == True,
                         Annotation.pagenumber == _pagenum - 1,
                         Annotation.redactionlayerid == redactionlayerid,
-                        Annotation.annotation.ilike("%<redact %"),
+                        Annotation.annotationtype == "redact",
                     )
                 )
                 .order_by(Annotation.annotationid.asc())
@@ -590,7 +590,7 @@ class Annotation(db.Model):
                         Annotation.isactive == True,
                         Annotation.pagenumber.in_(_pages),
                         Annotation.redactionlayerid == redactionlayerid,
-                        Annotation.annotation.ilike("%<redact %"),
+                        Annotation.annotationtype == "redact",
                     )
                 )
                 .order_by(Annotation.annotationid.asc())

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -27,6 +27,26 @@ def get_annotation_type(annotation_xml):
     return match.group(1).split(":")[-1].lower()
 
 
+def _build_annotation_values(
+    annot, redactionlayerid, userinfo, version, documentversion, annotationid=None
+):
+    values = {
+        "annotationname": annot["name"],
+        "documentid": annot["docid"],
+        "documentversion": documentversion,
+        "annotation": annot["xml"],
+        "annotationtype": get_annotation_type(annot["xml"]),
+        "pagenumber": annot["page"],
+        "createdby": userinfo,
+        "isactive": True,
+        "version": version,
+        "redactionlayerid": redactionlayerid,
+    }
+    if annotationid is not None:
+        values["annotationid"] = annotationid
+    return values
+
+
 class Annotation(db.Model):
     __tablename__ = "Annotations"
     # Defining the columns
@@ -291,10 +311,10 @@ class Annotation(db.Model):
             sql = """
                     insert into "Annotations" (annotationname, documentid , documentversion, 
                     annotation, pagenumber, isactive, createdby, created_at, updatedby, updated_at, 
-                    redactionlayerid, "version")                     
+                    redactionlayerid, "version", annotationtype)                     
                     select annotationname, documentid , documentversion, 
                     annotation, pagenumber, isactive, createdby, created_at, updatedby, updated_at, 
-                    :targetlayer, 1 from "Annotations" a 
+                    :targetlayer, 1, annotationtype from "Annotations" a 
                     where redactionlayerid in :sourceredactionlayers and isactive = true and documentid in :documentids;
        
                 """
@@ -366,17 +386,13 @@ class Annotation(db.Model):
     def __newannotation(cls, annot, redactionlayerid, userinfo) -> DefaultMethodResult:
         try:
             values = [
-                {
-                    "annotationname": annot["name"],
-                    "documentid": annot["docid"],
-                    "documentversion": 1,
-                    "annotation": annot["xml"],
-                    "pagenumber": annot["page"],
-                    "createdby": userinfo,
-                    "isactive": True,
-                    "version": 1,
-                    "redactionlayerid": redactionlayerid,
-                }
+                _build_annotation_values(
+                    annot,
+                    redactionlayerid,
+                    userinfo,
+                    version=1,
+                    documentversion=1,
+                )
             ]
             insertstmt = insert(Annotation).values(values)
             upsertstmt = insertstmt.on_conflict_do_update(
@@ -422,18 +438,14 @@ class Annotation(db.Model):
                     _pkvannots[annot["name"]] if _pkvannots not in (None, {}) else None
                 )
                 datalist.append(
-                    {
-                        "annotationname": annot["name"],
-                        "documentid": annot["docid"],
-                        "documentversion": 1,
-                        "annotation": annot["xml"],
-                        "pagenumber": annot["page"],
-                        "createdby": userinfo,
-                        "isactive": True,
-                        "redactionlayerid": redactionlayerid,
-                        "version": pkkey["version"] + 1 if pkkey is not None and "version" in pkkey else 1,
-                        "annotationid": pkkey["annotationid"] if pkkey is not None and "annotationid" in pkkey else None
-                    }
+                    _build_annotation_values(
+                        annot,
+                        redactionlayerid,
+                        userinfo,
+                        version=pkkey["version"] + 1 if pkkey is not None and "version" in pkkey else 1,
+                        documentversion=1,
+                        annotationid=pkkey["annotationid"] if pkkey is not None and "annotationid" in pkkey else None,
+                    )
                 )
                 idxannots.append(annot["name"])
             db.session.bulk_insert_mappings(Annotation, datalist)
@@ -454,18 +466,14 @@ class Annotation(db.Model):
                     True, "Unable to Save Annotation", annot["name"]
                 )
             values = [
-                {
-                    "annotationid": id,
-                    "annotationname": annot["name"],
-                    "documentid": annot["docid"],
-                    "documentversion": annot["docversion"],
-                    "annotation": annot["xml"],
-                    "pagenumber": annot["page"],
-                    "createdby": userinfo,
-                    "isactive": True,
-                    "version": version + 1,
-                    "redactionlayerid": redactionlayerid,
-                }
+                _build_annotation_values(
+                    annot,
+                    redactionlayerid,
+                    userinfo,
+                    version=version + 1,
+                    documentversion=annot["docversion"],
+                    annotationid=id,
+                )
             ]
             insertstmt = insert(Annotation).values(values)
             annotstmt = insertstmt.on_conflict_do_nothing()

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -36,6 +36,7 @@ class Annotation(db.Model):
     documentid = db.Column(db.Integer, db.ForeignKey("Documents.documentid"))
     documentversion = db.Column(db.Integer, db.ForeignKey("Documents.version"))
     annotation = db.Column(db.Text, unique=False, nullable=False)
+    annotationtype = db.Column(db.String(40), unique=False, nullable=True)
     pagenumber = db.Column(db.Integer, nullable=False)
     isactive = db.Column(db.Boolean, unique=False, nullable=False)
     createdby = db.Column(JSON, unique=False, nullable=True)

--- a/api/tests/unit/test_annotation_type.py
+++ b/api/tests/unit/test_annotation_type.py
@@ -1,0 +1,16 @@
+import inspect
+
+from reviewer_api.models import AnnotationSections
+from reviewer_api.models.Annotations import Annotation, get_annotation_type
+
+
+def test_get_annotation_type_returns_root_tag_name():
+    assert get_annotation_type('<redact page="1" />') == "redact"
+    assert get_annotation_type('  <freetext><contents>x</contents></freetext>') == "freetext"
+    assert get_annotation_type('<?xml version="1.0"?><highlight />') == "highlight"
+
+
+def test_get_annotation_type_returns_none_for_empty_or_invalid_xml():
+    assert get_annotation_type("") is None
+    assert get_annotation_type(None) is None
+    assert get_annotation_type("not xml") is None

--- a/api/tests/unit/test_annotation_type.py
+++ b/api/tests/unit/test_annotation_type.py
@@ -1,7 +1,11 @@
 import inspect
 
 from reviewer_api.models import AnnotationSections
-from reviewer_api.models.Annotations import Annotation, get_annotation_type
+from reviewer_api.models.Annotations import (
+    Annotation,
+    _build_annotation_values,
+    get_annotation_type,
+)
 
 
 def test_get_annotation_type_returns_root_tag_name():
@@ -14,3 +18,50 @@ def test_get_annotation_type_returns_none_for_empty_or_invalid_xml():
     assert get_annotation_type("") is None
     assert get_annotation_type(None) is None
     assert get_annotation_type("not xml") is None
+
+
+def test_new_annotation_values_include_annotation_type():
+    values = _build_annotation_values(
+        {"name": "a1", "docid": 10, "xml": '<redact page="1" />', "page": 0},
+        redactionlayerid=4,
+        userinfo={"userid": "u"},
+        version=1,
+        documentversion=1,
+    )
+
+    assert values["annotationtype"] == "redact"
+
+
+def test_bulk_annotation_values_include_annotation_type():
+    values = _build_annotation_values(
+        {"name": "a1", "docid": 10, "xml": '<redact page="1" />', "page": 0},
+        redactionlayerid=4,
+        userinfo={"userid": "u"},
+        version=3,
+        documentversion=1,
+        annotationid=99,
+    )
+
+    assert values["annotationtype"] == "redact"
+    assert values["version"] == 3
+    assert values["annotationid"] == 99
+
+
+def test_update_annotation_values_include_annotation_type():
+    values = _build_annotation_values(
+        {
+            "name": "a1",
+            "docid": 10,
+            "docversion": 2,
+            "xml": '<redact page="1" />',
+            "page": 0,
+        },
+        redactionlayerid=4,
+        userinfo={"userid": "u"},
+        version=4,
+        documentversion=2,
+        annotationid=99,
+    )
+
+    assert values["annotationtype"] == "redact"
+    assert values["documentversion"] == 2

--- a/api/tests/unit/test_annotation_type.py
+++ b/api/tests/unit/test_annotation_type.py
@@ -81,3 +81,11 @@ def test_getredactionsbydocumentpages_filters_by_annotation_type():
     assert "Annotation.annotationtype == \"redact\"" in source
     assert "Annotation.annotation.ilike" not in source
     assert "%<redact %" not in source
+
+
+def test_getredactedsectionsbyrequest_prefilters_by_annotation_type():
+    source = inspect.getsource(AnnotationSections.AnnotationSection.getredactedsectionsbyrequest)
+
+    assert "a.annotationtype = 'freetext'" in source
+    assert "a.annotation LIKE '%%freetext%%'" not in source
+    assert "a.annotation like '%%freetext%%'" not in source

--- a/api/tests/unit/test_annotation_type.py
+++ b/api/tests/unit/test_annotation_type.py
@@ -65,3 +65,19 @@ def test_update_annotation_values_include_annotation_type():
 
     assert values["annotationtype"] == "redact"
     assert values["documentversion"] == 2
+
+
+def test_getredactionsbypage_filters_by_annotation_type():
+    source = inspect.getsource(Annotation.getredactionsbypage)
+
+    assert "Annotation.annotationtype == \"redact\"" in source
+    assert "Annotation.annotation.ilike" not in source
+    assert "%<redact %" not in source
+
+
+def test_getredactionsbydocumentpages_filters_by_annotation_type():
+    source = inspect.getsource(Annotation.getredactionsbydocumentpages)
+
+    assert "Annotation.annotationtype == \"redact\"" in source
+    assert "Annotation.annotation.ilike" not in source
+    assert "%<redact %" not in source


### PR DESCRIPTION
  Adds normalized Apryse annotation type metadata so annotation reads can use indexed equality instead of XML text scans.

  - Added nullable `Annotations.annotationtype` column, backfill migration, and concurrent partial index.
  - Populates `annotationtype` on new, bulk, update, and copy annotation write paths.
  - Replaced hot redaction/freetext read filters with normalized `annotationtype` checks.
  - Added focused unit coverage and a production validation checklist.