### PR TITLE
fix: close annotation pagination DB session

### DIFF
--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -121,75 +121,78 @@ class Annotation(db.Model):
     def get_request_annotations_pagination(
         cls, ministryrequestid, mappedlayerids, page, size
     ):
-        _session = db.session
+        try:
+            _session = db.session
 
-        DM = aliased(DocumentMaster)
-        DD = aliased(DocumentDeleted)
+            DM = aliased(DocumentMaster)
+            DD = aliased(DocumentDeleted)
 
-        deleted_exists = (
-            db.session.query(literal(1))
-            .select_from(DM)
-            .join(
-                DD,
-                func.substring(DM.filepath, r'[0-9a-fA-F\-]{36}') ==
-                func.substring(DD.filepath, r'[0-9a-fA-F\-]{36}$')
-            )
-            .filter(
-                DM.documentmasterid == Document.documentmasterid,
-                DM.ministryrequestid == ministryrequestid,
-                DD.deleted.is_(True),
-            )
-            .exists()
-        ).correlate(Document)
+            deleted_exists = (
+                db.session.query(literal(1))
+                .select_from(DM)
+                .join(
+                    DD,
+                    func.substring(DM.filepath, r'[0-9a-fA-F\-]{36}') ==
+                    func.substring(DD.filepath, r'[0-9a-fA-F\-]{36}$')
+                )
+                .filter(
+                    DM.documentmasterid == Document.documentmasterid,
+                    DM.ministryrequestid == ministryrequestid,
+                    DD.deleted.is_(True),
+                )
+                .exists()
+            ).correlate(Document)
 
-        _originalnodonversionfiles = _session.query(DocumentMaster.documentmasterid).filter(
-            DocumentMaster.processingparentid == None,
-            DocumentMaster.ministryrequestid == ministryrequestid
-        ).subquery('sq')
-        _replacednoconversionfiles = _session.query(DocumentMaster.processingparentid).filter(
-            DocumentMaster.processingparentid != None,
-            DocumentMaster.ministryrequestid == ministryrequestid
-        ).subquery('sq2')
-        _replacedotherfiles = _session.query(func.max(DocumentMaster.documentmasterid).label('documentmasterid')).filter(
-            DocumentMaster.processingparentid != None,
-            DocumentMaster.ministryrequestid == ministryrequestid
-        ).group_by(DocumentMaster.processingparentid).subquery('sq3')
-        _subquery_annotation = (
-            _session.query(
-                Annotation.pagenumber, Annotation.annotation, Document.documentid
+            _originalnodonversionfiles = _session.query(DocumentMaster.documentmasterid).filter(
+                DocumentMaster.processingparentid == None,
+                DocumentMaster.ministryrequestid == ministryrequestid
+            ).subquery('sq')
+            _replacednoconversionfiles = _session.query(DocumentMaster.processingparentid).filter(
+                DocumentMaster.processingparentid != None,
+                DocumentMaster.ministryrequestid == ministryrequestid
+            ).subquery('sq2')
+            _replacedotherfiles = _session.query(func.max(DocumentMaster.documentmasterid).label('documentmasterid')).filter(
+                DocumentMaster.processingparentid != None,
+                DocumentMaster.ministryrequestid == ministryrequestid
+            ).group_by(DocumentMaster.processingparentid).subquery('sq3')
+            _subquery_annotation = (
+                _session.query(
+                    Annotation.pagenumber, Annotation.annotation, Document.documentid
+                )
+                .join(
+                    Document,
+                    and_(
+                        Annotation.documentid == Document.documentid,
+                        Document.foiministryrequestid == ministryrequestid,
+                    ),
+                )
+                .join(
+                    _originalnodonversionfiles, _originalnodonversionfiles.c.documentmasterid == Document.documentmasterid,
+                    isouter=True
+                )
+                .join(
+                    _replacedotherfiles, _replacedotherfiles.c.documentmasterid == Document.documentmasterid,
+                    isouter=True
+                )
+                .join(
+                    _replacednoconversionfiles, _replacednoconversionfiles.c.processingparentid == Document.documentmasterid,
+                    isouter=True
+                )
+                .filter(
+                    Annotation.redactionlayerid.in_(mappedlayerids),
+                    Annotation.isactive == True,
+                    or_(_originalnodonversionfiles.c.documentmasterid != None, _replacedotherfiles.c.documentmasterid != None),
+                    _replacednoconversionfiles.c.processingparentid == None,
+                    ~deleted_exists,
+                )
+                .order_by(
+                    Document.documentid, Annotation.pagenumber, Annotation.annotationid
+                )
             )
-            .join(
-                Document,
-                and_(
-                    Annotation.documentid == Document.documentid,
-                    Document.foiministryrequestid == ministryrequestid,
-                ),
-            )
-            .join(
-                _originalnodonversionfiles, _originalnodonversionfiles.c.documentmasterid == Document.documentmasterid,
-                isouter=True
-            )
-            .join(
-                _replacedotherfiles, _replacedotherfiles.c.documentmasterid == Document.documentmasterid,
-                isouter=True
-            )
-            .join(
-                _replacednoconversionfiles, _replacednoconversionfiles.c.processingparentid == Document.documentmasterid,
-                isouter=True
-            )
-            .filter(
-                Annotation.redactionlayerid.in_(mappedlayerids),
-                Annotation.isactive == True,
-                or_(_originalnodonversionfiles.c.documentmasterid != None, _replacedotherfiles.c.documentmasterid != None),
-                _replacednoconversionfiles.c.processingparentid == None,
-                ~deleted_exists,
-            )
-            .order_by(
-                Document.documentid, Annotation.pagenumber, Annotation.annotationid
-            )
-        )
-        result = _subquery_annotation.paginate(page=page, per_page=size)
-        return result
+            result = _subquery_annotation.paginate(page=page, per_page=size)
+            return result
+        finally:
+            db.session.close()
     
     @classmethod
     def get_document_annotations(cls, ministryrequestid, mappedlayerids, documentid):

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -121,6 +121,7 @@ class Annotation(db.Model):
     def get_request_annotations_pagination(
         cls, ministryrequestid, mappedlayerids, page, size
     ):
+        _session = None
         try:
             _session = db.session
 
@@ -128,7 +129,7 @@ class Annotation(db.Model):
             DD = aliased(DocumentDeleted)
 
             deleted_exists = (
-                db.session.query(literal(1))
+                _session.query(literal(1))
                 .select_from(DM)
                 .join(
                     DD,
@@ -192,7 +193,8 @@ class Annotation(db.Model):
             result = _subquery_annotation.paginate(page=page, per_page=size)
             return result
         finally:
-            db.session.close()
+            if _session is not None:
+                _session.close()
     
     @classmethod
     def get_document_annotations(cls, ministryrequestid, mappedlayerids, documentid):

--- a/api/reviewer_api/services/annotationservice.py
+++ b/api/reviewer_api/services/annotationservice.py
@@ -5,6 +5,7 @@ from reviewer_api.models.Annotations import Annotation
 from reviewer_api.models.AnnotationSections import AnnotationSection
 from reviewer_api.models.DocumentMaster import DocumentMaster
 from reviewer_api.models.DocumentPageflags import DocumentPageflag
+from reviewer_api.models.db import db
 
 from reviewer_api.schemas.annotationrequest import SectionAnnotationSchema
 
@@ -41,19 +42,22 @@ class annotationservice:
     def getrequestannotationspagination(
         self, ministryrequestid, mappedlayerids, page, size
     ):
-        result = Annotation.get_request_annotations_pagination(
-            ministryrequestid, mappedlayerids, page, size
-        )
-        meta = {
-            "page": result.page,
-            "pages": result.pages,
-            "total": result.total,
-            "prev_num": result.prev_num,
-            "next_num": result.next_num,
-            "has_next": result.has_next,
-            "has_prev": result.has_prev,
-        }
-        return {"data": self.__formatannotations(result.items), "meta": meta}
+        try:
+            result = Annotation.get_request_annotations_pagination(
+                ministryrequestid, mappedlayerids, page, size
+            )
+            meta = {
+                "page": result.page,
+                "pages": result.pages,
+                "total": result.total,
+                "prev_num": result.prev_num,
+                "next_num": result.next_num,
+                "has_next": result.has_next,
+                "has_prev": result.has_prev,
+            }
+            return {"data": self.__formatannotations(result.items), "meta": meta}
+        finally:
+            db.session.close()
     
     def getdocumentannotations(self, ministryrequestid, mappedlayerids, documentid):
         result = Annotation.get_document_annotations(ministryrequestid, mappedlayerids, documentid)

--- a/api/reviewer_api/services/annotationservice.py
+++ b/api/reviewer_api/services/annotationservice.py
@@ -5,7 +5,6 @@ from reviewer_api.models.Annotations import Annotation
 from reviewer_api.models.AnnotationSections import AnnotationSection
 from reviewer_api.models.DocumentMaster import DocumentMaster
 from reviewer_api.models.DocumentPageflags import DocumentPageflag
-from reviewer_api.models.db import db
 
 from reviewer_api.schemas.annotationrequest import SectionAnnotationSchema
 
@@ -42,22 +41,19 @@ class annotationservice:
     def getrequestannotationspagination(
         self, ministryrequestid, mappedlayerids, page, size
     ):
-        try:
-            result = Annotation.get_request_annotations_pagination(
-                ministryrequestid, mappedlayerids, page, size
-            )
-            meta = {
-                "page": result.page,
-                "pages": result.pages,
-                "total": result.total,
-                "prev_num": result.prev_num,
-                "next_num": result.next_num,
-                "has_next": result.has_next,
-                "has_prev": result.has_prev,
-            }
-            return {"data": self.__formatannotations(result.items), "meta": meta}
-        finally:
-            db.session.close()
+        result = Annotation.get_request_annotations_pagination(
+            ministryrequestid, mappedlayerids, page, size
+        )
+        meta = {
+            "page": result.page,
+            "pages": result.pages,
+            "total": result.total,
+            "prev_num": result.prev_num,
+            "next_num": result.next_num,
+            "has_next": result.has_next,
+            "has_prev": result.has_prev,
+        }
+        return {"data": self.__formatannotations(result.items), "meta": meta}
     
     def getdocumentannotations(self, ministryrequestid, mappedlayerids, documentid):
         result = Annotation.get_document_annotations(ministryrequestid, mappedlayerids, documentid)

--- a/api/tests/unit/test_annotation_pagination_session.py
+++ b/api/tests/unit/test_annotation_pagination_session.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from reviewer_api.services.annotationservice import annotationservice
+
+
+def test_getrequestannotationspagination_closes_session_after_formatting():
+    result = SimpleNamespace(
+        page=1,
+        pages=1,
+        total=1,
+        prev_num=None,
+        next_num=None,
+        has_next=False,
+        has_prev=False,
+        items=[
+            SimpleNamespace(
+                documentid=101,
+                annotation='<redact page="1" />',
+            )
+        ],
+    )
+
+    close_session = Mock()
+
+    with patch(
+        "reviewer_api.services.annotationservice.Annotation.get_request_annotations_pagination",
+        return_value=result,
+    ) as get_page, patch(
+        "reviewer_api.services.annotationservice.db.session.close",
+        close_session,
+    ):
+        response = annotationservice().getrequestannotationspagination(
+            ministryrequestid=627,
+            mappedlayerids=[3],
+            page=1,
+            size=3500,
+        )
+
+    get_page.assert_called_once_with(627, [3], 1, 3500)
+    close_session.assert_called_once()
+    assert response["meta"]["page"] == 1
+    assert 101 in response["data"]
+
+
+def test_getrequestannotationspagination_closes_session_when_formatting_fails():
+    result = SimpleNamespace(
+        page=1,
+        pages=1,
+        total=1,
+        prev_num=None,
+        next_num=None,
+        has_next=False,
+        has_prev=False,
+        items=[SimpleNamespace(documentid=101)],
+    )
+
+    close_session = Mock()
+
+    with patch(
+        "reviewer_api.services.annotationservice.Annotation.get_request_annotations_pagination",
+        return_value=result,
+    ), patch(
+        "reviewer_api.services.annotationservice.db.session.close",
+        close_session,
+    ):
+        try:
+            annotationservice().getrequestannotationspagination(627, [3], 1, 3500)
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError("Expected formatting to fail")
+
+    close_session.assert_called_once()

--- a/api/tests/unit/test_annotation_pagination_session.py
+++ b/api/tests/unit/test_annotation_pagination_session.py
@@ -1,10 +1,80 @@
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
+from reviewer_api.models.Annotations import Annotation
 from reviewer_api.services.annotationservice import annotationservice
 
 
-def test_getrequestannotationspagination_closes_session_after_formatting():
+def _query_chain():
+    query = Mock()
+    query.select_from.return_value = query
+    query.join.return_value = query
+    query.filter.return_value = query
+    query.group_by.return_value = query
+    query.order_by.return_value = query
+    query.subquery.return_value = SimpleNamespace(
+        c=SimpleNamespace(
+            documentmasterid=object(),
+            processingparentid=object(),
+        )
+    )
+    return query
+
+
+def _session_with_paginate(paginate):
+    deleted_exists = MagicMock()
+    deleted_exists.correlate.return_value = deleted_exists
+
+    deleted_query = _query_chain()
+    deleted_query.exists.return_value = deleted_exists
+
+    original_query = _query_chain()
+    replaced_no_conversion_query = _query_chain()
+    replaced_other_query = _query_chain()
+
+    annotation_query = _query_chain()
+    annotation_query.paginate = paginate
+
+    session = Mock()
+    session.query.side_effect = [
+        deleted_query,
+        original_query,
+        replaced_no_conversion_query,
+        replaced_other_query,
+        annotation_query,
+    ]
+    return session, annotation_query
+
+
+def test_get_request_annotations_pagination_closes_session_after_paginating():
+    expected = SimpleNamespace(items=[])
+    session, annotation_query = _session_with_paginate(Mock(return_value=expected))
+
+    with patch("reviewer_api.models.Annotations.db.session", session):
+        result = Annotation.get_request_annotations_pagination(627, [3], 1, 3500)
+
+    assert result is expected
+    annotation_query.paginate.assert_called_once_with(
+        page=1,
+        per_page=3500,
+    )
+    session.close.assert_called_once()
+
+
+def test_get_request_annotations_pagination_closes_session_when_paginate_fails():
+    paginate = Mock(side_effect=RuntimeError("database error"))
+    session, _annotation_query = _session_with_paginate(paginate)
+
+    with patch("reviewer_api.models.Annotations.db.session", session):
+        with pytest.raises(RuntimeError, match="database error"):
+            Annotation.get_request_annotations_pagination(627, [3], 1, 3500)
+
+    session.close.assert_called_once()
+
+
+def test_getrequestannotationspagination_formats_model_result():
     result = SimpleNamespace(
         page=1,
         pages=1,
@@ -21,15 +91,10 @@ def test_getrequestannotationspagination_closes_session_after_formatting():
         ],
     )
 
-    close_session = Mock()
-
     with patch(
         "reviewer_api.services.annotationservice.Annotation.get_request_annotations_pagination",
         return_value=result,
-    ) as get_page, patch(
-        "reviewer_api.services.annotationservice.db.session.close",
-        close_session,
-    ):
+    ) as get_page:
         response = annotationservice().getrequestannotationspagination(
             ministryrequestid=627,
             mappedlayerids=[3],
@@ -38,37 +103,5 @@ def test_getrequestannotationspagination_closes_session_after_formatting():
         )
 
     get_page.assert_called_once_with(627, [3], 1, 3500)
-    close_session.assert_called_once()
     assert response["meta"]["page"] == 1
     assert 101 in response["data"]
-
-
-def test_getrequestannotationspagination_closes_session_when_formatting_fails():
-    result = SimpleNamespace(
-        page=1,
-        pages=1,
-        total=1,
-        prev_num=None,
-        next_num=None,
-        has_next=False,
-        has_prev=False,
-        items=[SimpleNamespace(documentid=101)],
-    )
-
-    close_session = Mock()
-
-    with patch(
-        "reviewer_api.services.annotationservice.Annotation.get_request_annotations_pagination",
-        return_value=result,
-    ), patch(
-        "reviewer_api.services.annotationservice.db.session.close",
-        close_session,
-    ):
-        try:
-            annotationservice().getrequestannotationspagination(627, [3], 1, 3500)
-        except AttributeError:
-            pass
-        else:
-            raise AssertionError("Expected formatting to fail")
-
-    close_session.assert_called_once()


### PR DESCRIPTION
 - Added session cleanup inside `Annotation.get_request_annotations_pagination(...)`.
  - Kept DB session lifecycle ownership in the model/data-access layer, matching nearby annotation model methods.
  - Ensured the same `_session` instance is used for pagination query construction and closed in `finally`.
  - Added regression coverage for annotation pagination session cleanup.