### PR TITLE
Release 25.3

### DIFF
--- a/api/migrations/versions/2b4c7d6e8f90_add_annotation_type.py
+++ b/api/migrations/versions/2b4c7d6e8f90_add_annotation_type.py
@@ -1,0 +1,27 @@
+"""add annotation type
+
+Revision ID: 2b4c7d6e8f90
+Revises: 81eb14daaace
+Create Date: 2026-05-13 11:35:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2b4c7d6e8f90'
+down_revision = '81eb14daaace'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "Annotations",
+        sa.Column("annotationtype", sa.String(length=40), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("Annotations", "annotationtype")

--- a/api/migrations/versions/3c5d8e7f9012_backfill_annotation_type.py
+++ b/api/migrations/versions/3c5d8e7f9012_backfill_annotation_type.py
@@ -1,0 +1,33 @@
+"""backfill annotation type
+
+Revision ID: 3c5d8e7f9012
+Revises: 2b4c7d6e8f90
+Create Date: 2026-05-13 11:37:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '3c5d8e7f9012'
+down_revision = '2b4c7d6e8f90'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE public."Annotations"
+        SET annotationtype = lower(
+            substring(
+                annotation FROM '^\\s*(?:<\\?xml[^>]*\\?>\\s*)?<([A-Za-z_][A-Za-z0-9_.:-]*)[\\s>/]'
+            )
+        )
+        WHERE annotationtype IS NULL;
+        """
+    )
+
+
+def downgrade():
+    op.execute('UPDATE public."Annotations" SET annotationtype = NULL;')

--- a/api/migrations/versions/3c5d8e7f9012_backfill_annotation_type.py
+++ b/api/migrations/versions/3c5d8e7f9012_backfill_annotation_type.py
@@ -14,20 +14,45 @@ down_revision = '2b4c7d6e8f90'
 branch_labels = None
 depends_on = None
 
+BATCH_SIZE = 50000
+
 
 def upgrade():
-    op.execute(
-        """
-        UPDATE public."Annotations"
-        SET annotationtype = lower(
-            substring(
-                annotation FROM '^\\s*(?:<\\?xml[^>]*\\?>\\s*)?<([A-Za-z_][A-Za-z0-9_.:-]*)[\\s>/]'
-            )
-        )
-        WHERE annotationtype IS NULL;
-        """
-    )
+    bind = op.get_bind()
+
+    with op.get_context().autocommit_block():
+        while True:
+            updated_count = bind.execute(
+                sa.text(
+                    """
+                    WITH batch AS (
+                        SELECT annotationid, version
+                        FROM public."Annotations"
+                        WHERE annotationtype IS NULL
+                        ORDER BY annotationid, version
+                        LIMIT :batch_size
+                    ),
+                    updated AS (
+                        UPDATE public."Annotations" a
+                        SET annotationtype = lower(
+                            substring(
+                                a.annotation FROM '^\\s*(?:<\\?xml[^>]*\\?>\\s*)?<([A-Za-z_][A-Za-z0-9_.:-]*)[\\s>/]'
+                            )
+                        )
+                        FROM batch
+                        WHERE a.annotationid = batch.annotationid
+                          AND a.version = batch.version
+                        RETURNING 1
+                    )
+                    SELECT count(*) FROM updated;
+                    """
+                ),
+                {"batch_size": BATCH_SIZE},
+            ).scalar()
+
+            if updated_count == 0:
+                break
 
 
 def downgrade():
-    op.execute('UPDATE public."Annotations" SET annotationtype = NULL;')
+    pass

--- a/api/migrations/versions/4d6e9f801234_index_annotation_type.py
+++ b/api/migrations/versions/4d6e9f801234_index_annotation_type.py
@@ -1,0 +1,34 @@
+"""index annotation type
+
+Revision ID: 4d6e9f801234
+Revises: 3c5d8e7f9012
+Create Date: 2026-05-13 11:38:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '4d6e9f801234'
+down_revision = '3c5d8e7f9012'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS '
+            'idx_annotations_active_type_layer_doc_page '
+            'ON public."Annotations" '
+            '(annotationtype, redactionlayerid, documentid, documentversion, pagenumber) '
+            'WHERE isactive = TRUE'
+        )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute(
+            'DROP INDEX CONCURRENTLY IF EXISTS '
+            'public.idx_annotations_active_type_layer_doc_page'
+        )

--- a/api/reviewer_api/models/AnnotationSections.py
+++ b/api/reviewer_api/models/AnnotationSections.py
@@ -409,37 +409,9 @@ class AnnotationSection(db.Model):
                 JOIN public."DocumentMaster" dm ON dm.documentmasterid = d.documentmasterid 
                     AND dm.ministryrequestid = :ministryrequestid
                 LEFT JOIN non_deleted_files vd ON dm.filepath ILIKE vd.filepath || '%'
-                WHERE a.annotation LIKE '%%freetext%%'
+                WHERE a.annotationtype = 'freetext'
                     AND a.redactionlayerid = :redactionlayerid
                     AND a.isactive = TRUE;
-            """
-            """
-                select unnest(xpath('//contents/text()', annotation::xml))::text as section 
-                   from "Annotations" a 
-                        join public."Documents" d on d.documentid = a.documentid and d.foiministryrequestid = :ministryrequestid
-                        join public."DocumentMaster" dm on dm.documentmasterid = d.documentmasterid and dm.ministryrequestid = :ministryrequestid
-                        left join public."DocumentDeleted" dd on dm.filepath ilike dd.filepath || '%' and dd.ministryrequestid = :ministryrequestid
-                        where a.annotation like '%%freetext%%'
-                        and a.redactionlayerid = :redactionlayerid
-                        and (dd.deleted is null or dd.deleted is false)
-                        and a.isactive = true;
-
-            """
-            """
-            sql = select section from public."Sections" where sectionid in
-                        (select distinct (json_array_elements((as1.section::json->>'ids')::json)->>'id')::integer
-                        from public."AnnotationSections" as1
-                        join public."Annotations" a on a.annotationname = as1.annotationname
-                        join public."Documents" d on d.documentid = a.documentid and d.foiministryrequestid = :ministryrequestid
-                        join public."DocumentMaster" dm on dm.documentmasterid = d.documentmasterid and dm.ministryrequestid = :ministryrequestid
-                        left join public."DocumentDeleted" dd on dm.filepath ilike dd.filepath || '%' and dd.ministryrequestid = :ministryrequestid
-                        where as1.foiministryrequestid = :ministryrequestid and as1.isactive  = true
-                        and as1.redactionlayerid = a.redactionlayerid 
-                        and as1.redactionlayerid = :redactionlayerid
-                        and (dd.deleted is null or dd.deleted is false)
-                        and a.isactive = true)
-                     and sectionid != 25
-                     order by sortorder
             """
             rs = db.session.execute(text(sql), {"ministryrequestid": ministryrequestid, "redactionlayerid": redactionlayerid})
             sections = []

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -10,6 +10,21 @@ from reviewer_api.utils.util import split, getbatchconfig
 from .Documents import Document
 from .DocumentMaster import DocumentMaster
 from .DocumentDeleted import DocumentDeleted
+import re
+
+
+_ANNOTATION_TYPE_PATTERN = re.compile(
+    r'^\s*(?:<\?xml[^>]*\?>\s*)?<([A-Za-z_][A-Za-z0-9_.:-]*)(?:\s|/|>)'
+)
+
+
+def get_annotation_type(annotation_xml):
+    if not annotation_xml:
+        return None
+    match = _ANNOTATION_TYPE_PATTERN.search(annotation_xml)
+    if match is None:
+        return None
+    return match.group(1).split(":")[-1].lower()
 
 
 class Annotation(db.Model):

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -121,75 +121,78 @@ class Annotation(db.Model):
     def get_request_annotations_pagination(
         cls, ministryrequestid, mappedlayerids, page, size
     ):
-        _session = db.session
+        try:
+            _session = db.session
 
-        DM = aliased(DocumentMaster)
-        DD = aliased(DocumentDeleted)
+            DM = aliased(DocumentMaster)
+            DD = aliased(DocumentDeleted)
 
-        deleted_exists = (
-            db.session.query(literal(1))
-            .select_from(DM)
-            .join(
-                DD,
-                func.substring(DM.filepath, r'[0-9a-fA-F\-]{36}') ==
-                func.substring(DD.filepath, r'[0-9a-fA-F\-]{36}$')
-            )
-            .filter(
-                DM.documentmasterid == Document.documentmasterid,
-                DM.ministryrequestid == ministryrequestid,
-                DD.deleted.is_(True),
-            )
-            .exists()
-        ).correlate(Document)
+            deleted_exists = (
+                db.session.query(literal(1))
+                .select_from(DM)
+                .join(
+                    DD,
+                    func.substring(DM.filepath, r'[0-9a-fA-F\-]{36}') ==
+                    func.substring(DD.filepath, r'[0-9a-fA-F\-]{36}$')
+                )
+                .filter(
+                    DM.documentmasterid == Document.documentmasterid,
+                    DM.ministryrequestid == ministryrequestid,
+                    DD.deleted.is_(True),
+                )
+                .exists()
+            ).correlate(Document)
 
-        _originalnodonversionfiles = _session.query(DocumentMaster.documentmasterid).filter(
-            DocumentMaster.processingparentid == None,
-            DocumentMaster.ministryrequestid == ministryrequestid
-        ).subquery('sq')
-        _replacednoconversionfiles = _session.query(DocumentMaster.processingparentid).filter(
-            DocumentMaster.processingparentid != None,
-            DocumentMaster.ministryrequestid == ministryrequestid
-        ).subquery('sq2')
-        _replacedotherfiles = _session.query(func.max(DocumentMaster.documentmasterid).label('documentmasterid')).filter(
-            DocumentMaster.processingparentid != None,
-            DocumentMaster.ministryrequestid == ministryrequestid
-        ).group_by(DocumentMaster.processingparentid).subquery('sq3')
-        _subquery_annotation = (
-            _session.query(
-                Annotation.pagenumber, Annotation.annotation, Document.documentid
+            _originalnodonversionfiles = _session.query(DocumentMaster.documentmasterid).filter(
+                DocumentMaster.processingparentid == None,
+                DocumentMaster.ministryrequestid == ministryrequestid
+            ).subquery('sq')
+            _replacednoconversionfiles = _session.query(DocumentMaster.processingparentid).filter(
+                DocumentMaster.processingparentid != None,
+                DocumentMaster.ministryrequestid == ministryrequestid
+            ).subquery('sq2')
+            _replacedotherfiles = _session.query(func.max(DocumentMaster.documentmasterid).label('documentmasterid')).filter(
+                DocumentMaster.processingparentid != None,
+                DocumentMaster.ministryrequestid == ministryrequestid
+            ).group_by(DocumentMaster.processingparentid).subquery('sq3')
+            _subquery_annotation = (
+                _session.query(
+                    Annotation.pagenumber, Annotation.annotation, Document.documentid
+                )
+                .join(
+                    Document,
+                    and_(
+                        Annotation.documentid == Document.documentid,
+                        Document.foiministryrequestid == ministryrequestid,
+                    ),
+                )
+                .join(
+                    _originalnodonversionfiles, _originalnodonversionfiles.c.documentmasterid == Document.documentmasterid,
+                    isouter=True
+                )
+                .join(
+                    _replacedotherfiles, _replacedotherfiles.c.documentmasterid == Document.documentmasterid,
+                    isouter=True
+                )
+                .join(
+                    _replacednoconversionfiles, _replacednoconversionfiles.c.processingparentid == Document.documentmasterid,
+                    isouter=True
+                )
+                .filter(
+                    Annotation.redactionlayerid.in_(mappedlayerids),
+                    Annotation.isactive == True,
+                    or_(_originalnodonversionfiles.c.documentmasterid != None, _replacedotherfiles.c.documentmasterid != None),
+                    _replacednoconversionfiles.c.processingparentid == None,
+                    ~deleted_exists,
+                )
+                .order_by(
+                    Document.documentid, Annotation.pagenumber, Annotation.annotationid
+                )
             )
-            .join(
-                Document,
-                and_(
-                    Annotation.documentid == Document.documentid,
-                    Document.foiministryrequestid == ministryrequestid,
-                ),
-            )
-            .join(
-                _originalnodonversionfiles, _originalnodonversionfiles.c.documentmasterid == Document.documentmasterid,
-                isouter=True
-            )
-            .join(
-                _replacedotherfiles, _replacedotherfiles.c.documentmasterid == Document.documentmasterid,
-                isouter=True
-            )
-            .join(
-                _replacednoconversionfiles, _replacednoconversionfiles.c.processingparentid == Document.documentmasterid,
-                isouter=True
-            )
-            .filter(
-                Annotation.redactionlayerid.in_(mappedlayerids),
-                Annotation.isactive == True,
-                or_(_originalnodonversionfiles.c.documentmasterid != None, _replacedotherfiles.c.documentmasterid != None),
-                _replacednoconversionfiles.c.processingparentid == None,
-                ~deleted_exists,
-            )
-            .order_by(
-                Document.documentid, Annotation.pagenumber, Annotation.annotationid
-            )
-        )
-        result = _subquery_annotation.paginate(page=page, per_page=size)
-        return result
+            result = _subquery_annotation.paginate(page=page, per_page=size)
+            return result
+        finally:
+            db.session.close()
     
     @classmethod
     def get_document_annotations(cls, ministryrequestid, mappedlayerids, documentid):

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -121,6 +121,7 @@ class Annotation(db.Model):
     def get_request_annotations_pagination(
         cls, ministryrequestid, mappedlayerids, page, size
     ):
+        _session = None
         try:
             _session = db.session
 
@@ -128,7 +129,7 @@ class Annotation(db.Model):
             DD = aliased(DocumentDeleted)
 
             deleted_exists = (
-                db.session.query(literal(1))
+                _session.query(literal(1))
                 .select_from(DM)
                 .join(
                     DD,
@@ -192,7 +193,8 @@ class Annotation(db.Model):
             result = _subquery_annotation.paginate(page=page, per_page=size)
             return result
         finally:
-            db.session.close()
+            if _session is not None:
+                _session.close()
     
     @classmethod
     def get_document_annotations(cls, ministryrequestid, mappedlayerids, documentid):

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -236,7 +236,7 @@ class Annotation(db.Model):
                         Annotation.isactive == True,
                         Annotation.pagenumber == _pagenum - 1,
                         Annotation.redactionlayerid == redactionlayerid,
-                        Annotation.annotation.ilike("%<redact %"),
+                        Annotation.annotationtype == "redact",
                     )
                 )
                 .order_by(Annotation.annotationid.asc())
@@ -590,7 +590,7 @@ class Annotation(db.Model):
                         Annotation.isactive == True,
                         Annotation.pagenumber.in_(_pages),
                         Annotation.redactionlayerid == redactionlayerid,
-                        Annotation.annotation.ilike("%<redact %"),
+                        Annotation.annotationtype == "redact",
                     )
                 )
                 .order_by(Annotation.annotationid.asc())

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -27,6 +27,26 @@ def get_annotation_type(annotation_xml):
     return match.group(1).split(":")[-1].lower()
 
 
+def _build_annotation_values(
+    annot, redactionlayerid, userinfo, version, documentversion, annotationid=None
+):
+    values = {
+        "annotationname": annot["name"],
+        "documentid": annot["docid"],
+        "documentversion": documentversion,
+        "annotation": annot["xml"],
+        "annotationtype": get_annotation_type(annot["xml"]),
+        "pagenumber": annot["page"],
+        "createdby": userinfo,
+        "isactive": True,
+        "version": version,
+        "redactionlayerid": redactionlayerid,
+    }
+    if annotationid is not None:
+        values["annotationid"] = annotationid
+    return values
+
+
 class Annotation(db.Model):
     __tablename__ = "Annotations"
     # Defining the columns
@@ -291,10 +311,10 @@ class Annotation(db.Model):
             sql = """
                     insert into "Annotations" (annotationname, documentid , documentversion, 
                     annotation, pagenumber, isactive, createdby, created_at, updatedby, updated_at, 
-                    redactionlayerid, "version")                     
+                    redactionlayerid, "version", annotationtype)                     
                     select annotationname, documentid , documentversion, 
                     annotation, pagenumber, isactive, createdby, created_at, updatedby, updated_at, 
-                    :targetlayer, 1 from "Annotations" a 
+                    :targetlayer, 1, annotationtype from "Annotations" a 
                     where redactionlayerid in :sourceredactionlayers and isactive = true and documentid in :documentids;
        
                 """
@@ -366,17 +386,13 @@ class Annotation(db.Model):
     def __newannotation(cls, annot, redactionlayerid, userinfo) -> DefaultMethodResult:
         try:
             values = [
-                {
-                    "annotationname": annot["name"],
-                    "documentid": annot["docid"],
-                    "documentversion": 1,
-                    "annotation": annot["xml"],
-                    "pagenumber": annot["page"],
-                    "createdby": userinfo,
-                    "isactive": True,
-                    "version": 1,
-                    "redactionlayerid": redactionlayerid,
-                }
+                _build_annotation_values(
+                    annot,
+                    redactionlayerid,
+                    userinfo,
+                    version=1,
+                    documentversion=1,
+                )
             ]
             insertstmt = insert(Annotation).values(values)
             upsertstmt = insertstmt.on_conflict_do_update(
@@ -422,18 +438,14 @@ class Annotation(db.Model):
                     _pkvannots[annot["name"]] if _pkvannots not in (None, {}) else None
                 )
                 datalist.append(
-                    {
-                        "annotationname": annot["name"],
-                        "documentid": annot["docid"],
-                        "documentversion": 1,
-                        "annotation": annot["xml"],
-                        "pagenumber": annot["page"],
-                        "createdby": userinfo,
-                        "isactive": True,
-                        "redactionlayerid": redactionlayerid,
-                        "version": pkkey["version"] + 1 if pkkey is not None and "version" in pkkey else 1,
-                        "annotationid": pkkey["annotationid"] if pkkey is not None and "annotationid" in pkkey else None
-                    }
+                    _build_annotation_values(
+                        annot,
+                        redactionlayerid,
+                        userinfo,
+                        version=pkkey["version"] + 1 if pkkey is not None and "version" in pkkey else 1,
+                        documentversion=1,
+                        annotationid=pkkey["annotationid"] if pkkey is not None and "annotationid" in pkkey else None,
+                    )
                 )
                 idxannots.append(annot["name"])
             db.session.bulk_insert_mappings(Annotation, datalist)
@@ -454,18 +466,14 @@ class Annotation(db.Model):
                     True, "Unable to Save Annotation", annot["name"]
                 )
             values = [
-                {
-                    "annotationid": id,
-                    "annotationname": annot["name"],
-                    "documentid": annot["docid"],
-                    "documentversion": annot["docversion"],
-                    "annotation": annot["xml"],
-                    "pagenumber": annot["page"],
-                    "createdby": userinfo,
-                    "isactive": True,
-                    "version": version + 1,
-                    "redactionlayerid": redactionlayerid,
-                }
+                _build_annotation_values(
+                    annot,
+                    redactionlayerid,
+                    userinfo,
+                    version=version + 1,
+                    documentversion=annot["docversion"],
+                    annotationid=id,
+                )
             ]
             insertstmt = insert(Annotation).values(values)
             annotstmt = insertstmt.on_conflict_do_nothing()

--- a/api/reviewer_api/models/Annotations.py
+++ b/api/reviewer_api/models/Annotations.py
@@ -36,6 +36,7 @@ class Annotation(db.Model):
     documentid = db.Column(db.Integer, db.ForeignKey("Documents.documentid"))
     documentversion = db.Column(db.Integer, db.ForeignKey("Documents.version"))
     annotation = db.Column(db.Text, unique=False, nullable=False)
+    annotationtype = db.Column(db.String(40), unique=False, nullable=True)
     pagenumber = db.Column(db.Integer, nullable=False)
     isactive = db.Column(db.Boolean, unique=False, nullable=False)
     createdby = db.Column(JSON, unique=False, nullable=True)

--- a/api/reviewer_api/services/annotationservice.py
+++ b/api/reviewer_api/services/annotationservice.py
@@ -5,6 +5,7 @@ from reviewer_api.models.Annotations import Annotation
 from reviewer_api.models.AnnotationSections import AnnotationSection
 from reviewer_api.models.DocumentMaster import DocumentMaster
 from reviewer_api.models.DocumentPageflags import DocumentPageflag
+from reviewer_api.models.db import db
 
 from reviewer_api.schemas.annotationrequest import SectionAnnotationSchema
 
@@ -41,19 +42,22 @@ class annotationservice:
     def getrequestannotationspagination(
         self, ministryrequestid, mappedlayerids, page, size
     ):
-        result = Annotation.get_request_annotations_pagination(
-            ministryrequestid, mappedlayerids, page, size
-        )
-        meta = {
-            "page": result.page,
-            "pages": result.pages,
-            "total": result.total,
-            "prev_num": result.prev_num,
-            "next_num": result.next_num,
-            "has_next": result.has_next,
-            "has_prev": result.has_prev,
-        }
-        return {"data": self.__formatannotations(result.items), "meta": meta}
+        try:
+            result = Annotation.get_request_annotations_pagination(
+                ministryrequestid, mappedlayerids, page, size
+            )
+            meta = {
+                "page": result.page,
+                "pages": result.pages,
+                "total": result.total,
+                "prev_num": result.prev_num,
+                "next_num": result.next_num,
+                "has_next": result.has_next,
+                "has_prev": result.has_prev,
+            }
+            return {"data": self.__formatannotations(result.items), "meta": meta}
+        finally:
+            db.session.close()
     
     def getdocumentannotations(self, ministryrequestid, mappedlayerids, documentid):
         result = Annotation.get_document_annotations(ministryrequestid, mappedlayerids, documentid)

--- a/api/reviewer_api/services/annotationservice.py
+++ b/api/reviewer_api/services/annotationservice.py
@@ -5,7 +5,6 @@ from reviewer_api.models.Annotations import Annotation
 from reviewer_api.models.AnnotationSections import AnnotationSection
 from reviewer_api.models.DocumentMaster import DocumentMaster
 from reviewer_api.models.DocumentPageflags import DocumentPageflag
-from reviewer_api.models.db import db
 
 from reviewer_api.schemas.annotationrequest import SectionAnnotationSchema
 
@@ -42,22 +41,19 @@ class annotationservice:
     def getrequestannotationspagination(
         self, ministryrequestid, mappedlayerids, page, size
     ):
-        try:
-            result = Annotation.get_request_annotations_pagination(
-                ministryrequestid, mappedlayerids, page, size
-            )
-            meta = {
-                "page": result.page,
-                "pages": result.pages,
-                "total": result.total,
-                "prev_num": result.prev_num,
-                "next_num": result.next_num,
-                "has_next": result.has_next,
-                "has_prev": result.has_prev,
-            }
-            return {"data": self.__formatannotations(result.items), "meta": meta}
-        finally:
-            db.session.close()
+        result = Annotation.get_request_annotations_pagination(
+            ministryrequestid, mappedlayerids, page, size
+        )
+        meta = {
+            "page": result.page,
+            "pages": result.pages,
+            "total": result.total,
+            "prev_num": result.prev_num,
+            "next_num": result.next_num,
+            "has_next": result.has_next,
+            "has_prev": result.has_prev,
+        }
+        return {"data": self.__formatannotations(result.items), "meta": meta}
     
     def getdocumentannotations(self, ministryrequestid, mappedlayerids, documentid):
         result = Annotation.get_document_annotations(ministryrequestid, mappedlayerids, documentid)

--- a/api/tests/unit/test_annotation_pagination_session.py
+++ b/api/tests/unit/test_annotation_pagination_session.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from reviewer_api.services.annotationservice import annotationservice
+
+
+def test_getrequestannotationspagination_closes_session_after_formatting():
+    result = SimpleNamespace(
+        page=1,
+        pages=1,
+        total=1,
+        prev_num=None,
+        next_num=None,
+        has_next=False,
+        has_prev=False,
+        items=[
+            SimpleNamespace(
+                documentid=101,
+                annotation='<redact page="1" />',
+            )
+        ],
+    )
+
+    close_session = Mock()
+
+    with patch(
+        "reviewer_api.services.annotationservice.Annotation.get_request_annotations_pagination",
+        return_value=result,
+    ) as get_page, patch(
+        "reviewer_api.services.annotationservice.db.session.close",
+        close_session,
+    ):
+        response = annotationservice().getrequestannotationspagination(
+            ministryrequestid=627,
+            mappedlayerids=[3],
+            page=1,
+            size=3500,
+        )
+
+    get_page.assert_called_once_with(627, [3], 1, 3500)
+    close_session.assert_called_once()
+    assert response["meta"]["page"] == 1
+    assert 101 in response["data"]
+
+
+def test_getrequestannotationspagination_closes_session_when_formatting_fails():
+    result = SimpleNamespace(
+        page=1,
+        pages=1,
+        total=1,
+        prev_num=None,
+        next_num=None,
+        has_next=False,
+        has_prev=False,
+        items=[SimpleNamespace(documentid=101)],
+    )
+
+    close_session = Mock()
+
+    with patch(
+        "reviewer_api.services.annotationservice.Annotation.get_request_annotations_pagination",
+        return_value=result,
+    ), patch(
+        "reviewer_api.services.annotationservice.db.session.close",
+        close_session,
+    ):
+        try:
+            annotationservice().getrequestannotationspagination(627, [3], 1, 3500)
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError("Expected formatting to fail")
+
+    close_session.assert_called_once()

--- a/api/tests/unit/test_annotation_pagination_session.py
+++ b/api/tests/unit/test_annotation_pagination_session.py
@@ -1,10 +1,80 @@
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
+from reviewer_api.models.Annotations import Annotation
 from reviewer_api.services.annotationservice import annotationservice
 
 
-def test_getrequestannotationspagination_closes_session_after_formatting():
+def _query_chain():
+    query = Mock()
+    query.select_from.return_value = query
+    query.join.return_value = query
+    query.filter.return_value = query
+    query.group_by.return_value = query
+    query.order_by.return_value = query
+    query.subquery.return_value = SimpleNamespace(
+        c=SimpleNamespace(
+            documentmasterid=object(),
+            processingparentid=object(),
+        )
+    )
+    return query
+
+
+def _session_with_paginate(paginate):
+    deleted_exists = MagicMock()
+    deleted_exists.correlate.return_value = deleted_exists
+
+    deleted_query = _query_chain()
+    deleted_query.exists.return_value = deleted_exists
+
+    original_query = _query_chain()
+    replaced_no_conversion_query = _query_chain()
+    replaced_other_query = _query_chain()
+
+    annotation_query = _query_chain()
+    annotation_query.paginate = paginate
+
+    session = Mock()
+    session.query.side_effect = [
+        deleted_query,
+        original_query,
+        replaced_no_conversion_query,
+        replaced_other_query,
+        annotation_query,
+    ]
+    return session, annotation_query
+
+
+def test_get_request_annotations_pagination_closes_session_after_paginating():
+    expected = SimpleNamespace(items=[])
+    session, annotation_query = _session_with_paginate(Mock(return_value=expected))
+
+    with patch("reviewer_api.models.Annotations.db.session", session):
+        result = Annotation.get_request_annotations_pagination(627, [3], 1, 3500)
+
+    assert result is expected
+    annotation_query.paginate.assert_called_once_with(
+        page=1,
+        per_page=3500,
+    )
+    session.close.assert_called_once()
+
+
+def test_get_request_annotations_pagination_closes_session_when_paginate_fails():
+    paginate = Mock(side_effect=RuntimeError("database error"))
+    session, _annotation_query = _session_with_paginate(paginate)
+
+    with patch("reviewer_api.models.Annotations.db.session", session):
+        with pytest.raises(RuntimeError, match="database error"):
+            Annotation.get_request_annotations_pagination(627, [3], 1, 3500)
+
+    session.close.assert_called_once()
+
+
+def test_getrequestannotationspagination_formats_model_result():
     result = SimpleNamespace(
         page=1,
         pages=1,
@@ -21,15 +91,10 @@ def test_getrequestannotationspagination_closes_session_after_formatting():
         ],
     )
 
-    close_session = Mock()
-
     with patch(
         "reviewer_api.services.annotationservice.Annotation.get_request_annotations_pagination",
         return_value=result,
-    ) as get_page, patch(
-        "reviewer_api.services.annotationservice.db.session.close",
-        close_session,
-    ):
+    ) as get_page:
         response = annotationservice().getrequestannotationspagination(
             ministryrequestid=627,
             mappedlayerids=[3],
@@ -38,37 +103,5 @@ def test_getrequestannotationspagination_closes_session_after_formatting():
         )
 
     get_page.assert_called_once_with(627, [3], 1, 3500)
-    close_session.assert_called_once()
     assert response["meta"]["page"] == 1
     assert 101 in response["data"]
-
-
-def test_getrequestannotationspagination_closes_session_when_formatting_fails():
-    result = SimpleNamespace(
-        page=1,
-        pages=1,
-        total=1,
-        prev_num=None,
-        next_num=None,
-        has_next=False,
-        has_prev=False,
-        items=[SimpleNamespace(documentid=101)],
-    )
-
-    close_session = Mock()
-
-    with patch(
-        "reviewer_api.services.annotationservice.Annotation.get_request_annotations_pagination",
-        return_value=result,
-    ), patch(
-        "reviewer_api.services.annotationservice.db.session.close",
-        close_session,
-    ):
-        try:
-            annotationservice().getrequestannotationspagination(627, [3], 1, 3500)
-        except AttributeError:
-            pass
-        else:
-            raise AssertionError("Expected formatting to fail")
-
-    close_session.assert_called_once()

--- a/api/tests/unit/test_annotation_type.py
+++ b/api/tests/unit/test_annotation_type.py
@@ -1,0 +1,16 @@
+import inspect
+
+from reviewer_api.models import AnnotationSections
+from reviewer_api.models.Annotations import Annotation, get_annotation_type
+
+
+def test_get_annotation_type_returns_root_tag_name():
+    assert get_annotation_type('<redact page="1" />') == "redact"
+    assert get_annotation_type('  <freetext><contents>x</contents></freetext>') == "freetext"
+    assert get_annotation_type('<?xml version="1.0"?><highlight />') == "highlight"
+
+
+def test_get_annotation_type_returns_none_for_empty_or_invalid_xml():
+    assert get_annotation_type("") is None
+    assert get_annotation_type(None) is None
+    assert get_annotation_type("not xml") is None

--- a/api/tests/unit/test_annotation_type.py
+++ b/api/tests/unit/test_annotation_type.py
@@ -1,7 +1,11 @@
 import inspect
 
 from reviewer_api.models import AnnotationSections
-from reviewer_api.models.Annotations import Annotation, get_annotation_type
+from reviewer_api.models.Annotations import (
+    Annotation,
+    _build_annotation_values,
+    get_annotation_type,
+)
 
 
 def test_get_annotation_type_returns_root_tag_name():
@@ -14,3 +18,50 @@ def test_get_annotation_type_returns_none_for_empty_or_invalid_xml():
     assert get_annotation_type("") is None
     assert get_annotation_type(None) is None
     assert get_annotation_type("not xml") is None
+
+
+def test_new_annotation_values_include_annotation_type():
+    values = _build_annotation_values(
+        {"name": "a1", "docid": 10, "xml": '<redact page="1" />', "page": 0},
+        redactionlayerid=4,
+        userinfo={"userid": "u"},
+        version=1,
+        documentversion=1,
+    )
+
+    assert values["annotationtype"] == "redact"
+
+
+def test_bulk_annotation_values_include_annotation_type():
+    values = _build_annotation_values(
+        {"name": "a1", "docid": 10, "xml": '<redact page="1" />', "page": 0},
+        redactionlayerid=4,
+        userinfo={"userid": "u"},
+        version=3,
+        documentversion=1,
+        annotationid=99,
+    )
+
+    assert values["annotationtype"] == "redact"
+    assert values["version"] == 3
+    assert values["annotationid"] == 99
+
+
+def test_update_annotation_values_include_annotation_type():
+    values = _build_annotation_values(
+        {
+            "name": "a1",
+            "docid": 10,
+            "docversion": 2,
+            "xml": '<redact page="1" />',
+            "page": 0,
+        },
+        redactionlayerid=4,
+        userinfo={"userid": "u"},
+        version=4,
+        documentversion=2,
+        annotationid=99,
+    )
+
+    assert values["annotationtype"] == "redact"
+    assert values["documentversion"] == 2

--- a/api/tests/unit/test_annotation_type.py
+++ b/api/tests/unit/test_annotation_type.py
@@ -81,3 +81,11 @@ def test_getredactionsbydocumentpages_filters_by_annotation_type():
     assert "Annotation.annotationtype == \"redact\"" in source
     assert "Annotation.annotation.ilike" not in source
     assert "%<redact %" not in source
+
+
+def test_getredactedsectionsbyrequest_prefilters_by_annotation_type():
+    source = inspect.getsource(AnnotationSections.AnnotationSection.getredactedsectionsbyrequest)
+
+    assert "a.annotationtype = 'freetext'" in source
+    assert "a.annotation LIKE '%%freetext%%'" not in source
+    assert "a.annotation like '%%freetext%%'" not in source

--- a/api/tests/unit/test_annotation_type.py
+++ b/api/tests/unit/test_annotation_type.py
@@ -65,3 +65,19 @@ def test_update_annotation_values_include_annotation_type():
 
     assert values["annotationtype"] == "redact"
     assert values["documentversion"] == 2
+
+
+def test_getredactionsbypage_filters_by_annotation_type():
+    source = inspect.getsource(Annotation.getredactionsbypage)
+
+    assert "Annotation.annotationtype == \"redact\"" in source
+    assert "Annotation.annotation.ilike" not in source
+    assert "%<redact %" not in source
+
+
+def test_getredactionsbydocumentpages_filters_by_annotation_type():
+    source = inspect.getsource(Annotation.getredactionsbydocumentpages)
+
+    assert "Annotation.annotationtype == \"redact\"" in source
+    assert "Annotation.annotation.ilike" not in source
+    assert "%<redact %" not in source


### PR DESCRIPTION
Cherry-pick annotation performance and DB session fixes from `dev` into `main`.

### Included changes

#### Annotation type optimization

* Added `annotationtype` column to normalize annotation lookup
* Populate annotation type during annotation writes
* Added migration/backfill scripts for existing records
* Added batched backfill migration to reduce DB pressure during migration
* Added tests covering annotation type extraction

#### Query performance improvements

* Optimized redaction queries to filter by `annotationtype`
* Prefiltered freetext annotation queries by type
* Added index for active annotations by type to improve query performance and reduce expensive scans

#### DB session handling fixes

* Fixed annotation pagination DB session leaks
* Standardized pagination session usage across model/service layers
* Improved session cleanup consistency

### Goal

Reduce annotation query execution time, avoid expensive XML/text scans, improve redaction loading performance, and fix DB session handling issues observed in production.
