### PR TITLE
Foimod-4729 summary generation optimization

### DIFF
--- a/computingservices/DocumentServices/services/dal/documentpageflag.py
+++ b/computingservices/DocumentServices/services/dal/documentpageflag.py
@@ -259,6 +259,7 @@ class documentpageflag:
 
         conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         sections = []
+        cursor = None
         try:
             cursor = conn.cursor()
             documentids = [pair[0] for pair in requested_pairs]
@@ -285,7 +286,6 @@ class documentpageflag:
             )
 
             result = cursor.fetchall()
-            cursor.close()
             if result is not None:
                 for entry in result:
                     sections.append({"documentid": entry[0], "pageno": entry[1], "section": entry[2]})
@@ -300,6 +300,8 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
+            if cursor is not None:
+                cursor.close()
             if should_close_conn and conn is not None:
                 conn.close()
 

--- a/computingservices/DocumentServices/services/dal/documentpageflag.py
+++ b/computingservices/DocumentServices/services/dal/documentpageflag.py
@@ -238,6 +238,66 @@ class documentpageflag:
                 conn.close()
 
     @classmethod
+    def getsections_batch(cls, redactionlayerid, document_pages):
+        start_time = time.time()
+        if not document_pages:
+            return []
+
+        requested_pairs = [
+            (int(documentid), int(pageno))
+            for documentid, pagenos in document_pages.items()
+            for pageno in sorted(set(pagenos))
+        ]
+        if not requested_pairs:
+            return []
+
+        conn = getdbconnection()
+        sections = []
+        try:
+            cursor = conn.cursor()
+            documentids = [pair[0] for pair in requested_pairs]
+            pagenumbers = [pair[1] for pair in requested_pairs]
+            cursor.execute(
+                """
+                WITH requested_pages AS (
+                    SELECT *
+                    FROM unnest(%s::integer[], %s::integer[]) AS rp(documentid, pagenumber)
+                )
+                SELECT a.documentid,
+                       a.pagenumber,
+                       unnest(xpath('//contents/text()', a.annotation::xml))::text AS sections
+                FROM "Annotations" a
+                JOIN requested_pages rp
+                  ON rp.documentid = a.documentid
+                 AND rp.pagenumber = a.pagenumber
+                WHERE a.isactive = true
+                  AND a.redactionlayerid = %s::integer
+                  AND a.annotationtype = 'freetext'
+                ORDER BY a.documentid, a.pagenumber;
+                """,
+                (documentids, pagenumbers, redactionlayerid),
+            )
+
+            result = cursor.fetchall()
+            cursor.close()
+            if result is not None:
+                for entry in result:
+                    sections.append({"documentid": entry[0], "pageno": entry[1], "section": entry[2]})
+            logging.info(
+                f"[PERF] DAL getsections_batch layer={redactionlayerid} docs={len(document_pages)} "
+                f"pages={len(requested_pairs)} elapsed={time.time() - start_time:.3f}s"
+            )
+            return sections
+
+        except Exception as error:
+            logging.error("Error in getting batched sections for requestid")
+            logging.error(error)
+            raise
+        finally:
+            if conn is not None:
+                conn.close()
+
+    @classmethod
     def getdeletedpages(cls, ministryrequestid, docids):
         start_time = time.time()
         conn = getdbconnection()

--- a/computingservices/DocumentServices/services/dal/documentpageflag.py
+++ b/computingservices/DocumentServices/services/dal/documentpageflag.py
@@ -353,7 +353,9 @@ class documentpageflag:
                 order by created_at, id desc limit 1;
             '''
             cursor.execute(query, (ministryrequestid,))
-            layerid = cursor.fetchone()
+            result = cursor.fetchone()
+            if result is not None:
+                layerid = result[0]
             logging.info(f"[PERF] DAL getrecentredactionlayerid request={ministryrequestid} elapsed={time.time() - start_time:.3f}s")
             return layerid
         except Exception as error:

--- a/computingservices/DocumentServices/services/dal/documentpageflag.py
+++ b/computingservices/DocumentServices/services/dal/documentpageflag.py
@@ -5,10 +5,16 @@ import time
 
 class documentpageflag:
 
+    @staticmethod
+    def __resolve_connection(connection_factory, conn=None):
+        if conn is not None:
+            return conn, False
+        return connection_factory(), True
+
     @classmethod
-    def get_all_pageflags(cls, ignoreflags):
+    def get_all_pageflags(cls, ignoreflags, conn=None):
         start_time = time.time()
-        conn = getdbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         pageflags = []
         try:
             cursor = conn.cursor()
@@ -33,13 +39,13 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
-            if conn is not None:
+            if should_close_conn and conn is not None:
                 conn.close()
 
     @classmethod
-    def get_all_programareas(cls):
+    def get_all_programareas(cls, conn=None):
         start_time = time.time()
-        conn = getfoidbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getfoidbconnection, conn)
         programareas = {}
         try:
             cursor = conn.cursor()
@@ -64,13 +70,13 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
-            if conn is not None:
+            if should_close_conn and conn is not None:
                 conn.close()
 
     @classmethod
-    def get_documentpageflag(cls, ministryrequestid, redactionlayerid, documentids):
+    def get_documentpageflag(cls, ministryrequestid, redactionlayerid, documentids, conn=None):
         start_time = time.time()
-        conn = getdbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         documentpageflags = {}
         try:
             cursor = conn.cursor()
@@ -98,7 +104,7 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
-            if conn is not None:
+            if should_close_conn and conn is not None:
                 conn.close()
 
     @classmethod
@@ -138,9 +144,9 @@ class documentpageflag:
 
 
     @classmethod
-    def getpagecount_by_documentid(cls, ministryrequestid, documentids):
+    def getpagecount_by_documentid(cls, ministryrequestid, documentids, conn=None):
         start_time = time.time()
-        conn = getdbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         docpgs = {}
         try:
             cursor = conn.cursor()
@@ -166,13 +172,13 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
-            if conn is not None:
+            if should_close_conn and conn is not None:
                 conn.close()
     
     @classmethod
-    def getoriginalpagecount_by_documentid(cls, ministryrequestid, documentids):
+    def getoriginalpagecount_by_documentid(cls, ministryrequestid, documentids, conn=None):
         start_time = time.time()
-        conn = getdbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         docpgs = {}
         try:
             cursor = conn.cursor()
@@ -198,13 +204,13 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
-            if conn is not None:
+            if should_close_conn and conn is not None:
                 conn.close()
 
     @classmethod
-    def getsections_by_documentid_pageno(cls, redactionlayerid, documentid, pagenos):
+    def getsections_by_documentid_pageno(cls, redactionlayerid, documentid, pagenos, conn=None):
         start_time = time.time()
-        conn = getdbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         sections = []
         try:
             cursor = conn.cursor()
@@ -234,11 +240,11 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
-            if conn is not None:
+            if should_close_conn and conn is not None:
                 conn.close()
 
     @classmethod
-    def getsections_batch(cls, redactionlayerid, document_pages):
+    def getsections_batch(cls, redactionlayerid, document_pages, conn=None):
         start_time = time.time()
         if not document_pages:
             return []
@@ -251,7 +257,7 @@ class documentpageflag:
         if not requested_pairs:
             return []
 
-        conn = getdbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         sections = []
         try:
             cursor = conn.cursor()
@@ -294,13 +300,13 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
-            if conn is not None:
+            if should_close_conn and conn is not None:
                 conn.close()
 
     @classmethod
-    def getdeletedpages(cls, ministryrequestid, docids):
+    def getdeletedpages(cls, ministryrequestid, docids, conn=None):
         start_time = time.time()
-        conn = getdbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         deldocpages = []
         try:
             cursor = conn.cursor()
@@ -326,14 +332,15 @@ class documentpageflag:
             logging.error(error)
             raise
         finally:
-            if conn is not None:
+            if should_close_conn and conn is not None:
                 conn.close()
 
     @classmethod
-    def getrecentredactionlayerid(cls, ministryrequestid):
+    def getrecentredactionlayerid(cls, ministryrequestid, conn=None):
         start_time = time.time()
-        conn = getdbconnection()
+        conn, should_close_conn = cls.__resolve_connection(getdbconnection, conn)
         layerid = 1
+        cursor = None
         try:
             cursor = conn.cursor()
             query = '''
@@ -353,6 +360,7 @@ class documentpageflag:
             logging.error("Error in getting recentredactionlayerid for requestid")
             logging.error(error)
         finally:
-            cursor.close()
-            if conn is not None:
+            if cursor is not None:
+                cursor.close()
+            if should_close_conn and conn is not None:
                 conn.close()

--- a/computingservices/DocumentServices/services/dts/redactionsummary.py
+++ b/computingservices/DocumentServices/services/dts/redactionsummary.py
@@ -8,13 +8,13 @@ import logging
 
 class redactionsummary():
 
-    def prepareredactionsummary(self, message, documentids, pageflags, programareas):
+    def prepareredactionsummary(self, message, documentids, pageflags, programareas, doc_conn=None):
         start_time = time.time()
         _ismcfpersonalrequest = True if message.bcgovcode == 'mcf' and message.requesttype == 'personal' else False
         if _ismcfpersonalrequest and (message.category in ("responsepackage", "openinfo") or  "responsepackage_phase" in message.category):
-            redactionsummary = self.__packagesummaryforcfdrequests(message, documentids)
+            redactionsummary = self.__packagesummaryforcfdrequests(message, documentids, doc_conn=doc_conn)
         else:
-            redactionsummary = self.__packaggesummary(message, documentids, pageflags, programareas)
+            redactionsummary = self.__packaggesummary(message, documentids, pageflags, programareas, doc_conn=doc_conn)
         if (message.category in ("responsepackage", "openinfo") or "responsepackage_phase" in message.category) and _ismcfpersonalrequest == False:
             consolidated_redactions = []
             for entry in redactionsummary['data']:
@@ -30,17 +30,17 @@ class redactionsummary():
         rangestart = str(rangestart).split('(')[0]
         return int(rangestart)
 
-    def __packaggesummary(self, message, documentids, pageflags, programareas):
+    def __packaggesummary(self, message, documentids, pageflags, programareas, doc_conn=None):
         start_time = time.time()
         try:
             print("\nInside __packaggesummary")
-            redactionlayerid = self.__getredactionlayerid(message)
+            redactionlayerid = self.__getredactionlayerid(message, doc_conn=doc_conn)
             summarymsg = message.summarydocuments
             summaryobject = get_in_summary_object(summarymsg)
             ordereddocids = summaryobject.sorteddocuments
-            stitchedpagedata = documentpageflag().getpagecount_by_documentid(message.ministryrequestid, ordereddocids)
+            stitchedpagedata = documentpageflag().getpagecount_by_documentid(message.ministryrequestid, ordereddocids, conn=doc_conn)
             totalpagecount = self.__calculate_totalpages(stitchedpagedata)
-            originalpagedata = None if "responsepackage_phase" not in message.category else documentpageflag().getoriginalpagecount_by_documentid(message.ministryrequestid, ordereddocids)
+            originalpagedata = None if "responsepackage_phase" not in message.category else documentpageflag().getoriginalpagecount_by_documentid(message.ministryrequestid, ordereddocids, conn=doc_conn)
             print("\n __packaggesummary stitchedpagedata",stitchedpagedata)
             print("\n __packaggesummary totalpagecount",totalpagecount)
             if totalpagecount <=0:
@@ -48,7 +48,7 @@ class redactionsummary():
             _pageflags = self.__transformpageflags(pageflags)
             print("\n_pageflags",_pageflags)
             summarydata = []
-            docpageflags = documentpageflag().get_documentpageflag(message.ministryrequestid, redactionlayerid, ordereddocids)
+            docpageflags = documentpageflag().get_documentpageflag(message.ministryrequestid, redactionlayerid, ordereddocids, conn=doc_conn)
             # this will remove any pages from docpageflags[pageflags] that are not associated with the redline phase for each doc
             phase = message.phase
             if phase is not None and phase !="" and 'redline_phase' in message.category:
@@ -65,7 +65,7 @@ class redactionsummary():
                     pageflags = docpageflags[docid]['pageflag']
                     docpageflags[docid]['pageflag'] = [flagobj for flagobj in pageflags if docid in docpagephase_map and flagobj['page'] in docpagephase_map[docid]]
             print("\n docpageflags",docpageflags)
-            deletedpages = self.__getdeletedpages(message.ministryrequestid, ordereddocids)
+            deletedpages = self.__getdeletedpages(message.ministryrequestid, ordereddocids, doc_conn=doc_conn)
             skippages= []     
             pagecount = 0
             try:
@@ -90,7 +90,7 @@ class redactionsummary():
                                 print("\nfilteredpages:",filteredpages)
                                 if len(filteredpages) > 0:
                                     originalpagenos = [pg['originalpageno'] for pg in filteredpages]
-                                    docpagesections = documentpageflag().getsections_by_documentid_pageno(redactionlayerid, docid, originalpagenos)
+                                    docpagesections = documentpageflag().getsections_by_documentid_pageno(redactionlayerid, docid, originalpagenos, conn=doc_conn)
                                     docpageconsults = self.__get_consults_by_pageno(programareas, docpageflag["pageflag"], filteredpages)
                                     pageflag['docpageflags'] = pageflag['docpageflags'] + self.__get_pagesection_mapping(filteredpages, docpagesections, docpageconsults)
                             skippages = self.__get_skippagenos(docpageflag['pageflag'], message.category, docdeletedpages, pageswithphases,pageswithnoflags)
@@ -128,15 +128,15 @@ class redactionsummary():
 
 
 
-    def __packagesummaryforcfdrequests(self, message, documentids):
+    def __packagesummaryforcfdrequests(self, message, documentids, doc_conn=None):
         start_time = time.time()
         try:
             print("\nInside logic for __packagesummaryforcfdrequests")
-            redactionlayerid = self.__getredactionlayerid(message)
+            redactionlayerid = self.__getredactionlayerid(message, doc_conn=doc_conn)
             summarymsg = message.summarydocuments
             summaryobject = get_in_summary_object(summarymsg)
             ordereddocids = summaryobject.sorteddocuments
-            stitchedpagedata = documentpageflag().getpagecount_by_documentid(message.ministryrequestid, ordereddocids)
+            stitchedpagedata = documentpageflag().getpagecount_by_documentid(message.ministryrequestid, ordereddocids, conn=doc_conn)
             totalpagecount = self.__calculate_totalpages(stitchedpagedata)
 
             if totalpagecount <= 0:
@@ -146,7 +146,7 @@ class redactionsummary():
             records = pkgdocuments[0].get('records', [])
             summarydata = []
 
-            docpageflags = documentpageflag().get_documentpageflag(message.ministryrequestid, redactionlayerid, ordereddocids)
+            docpageflags = documentpageflag().get_documentpageflag(message.ministryrequestid, redactionlayerid, ordereddocids, conn=doc_conn)
             # this will remove any pages from docpageflags[pageflags] that are not associated with the redline phase for each doc
             phase = message.phase
             if phase is not None and phase !="":
@@ -165,7 +165,7 @@ class redactionsummary():
             
             sorted_docpageflags = {k: docpageflags[k] for k in ordereddocids if k in docpageflags}
             # print("============>sorted_docpageflags:", sorted_docpageflags)
-            deletedpages = self.__getdeletedpages(message.ministryrequestid, ordereddocids)
+            deletedpages = self.__getdeletedpages(message.ministryrequestid, ordereddocids, doc_conn=doc_conn)
             # print("============>deletedpages:", deletedpages)
             mapped_flags = self.process_page_flags(sorted_docpageflags,deletedpages)
             print("###mapped_flags1:",mapped_flags)
@@ -176,7 +176,7 @@ class redactionsummary():
             #document_pages = self.__get_document_pages(docpageflags)
             #original_pages = self.__adjust_original_pages(document_pages)
             if pagecounts:
-                self.assignfullpagesections(redactionlayerid, mapped_flags)
+                self.assignfullpagesections(redactionlayerid, mapped_flags, doc_conn=doc_conn)
             end_page = 0
             for record in records:
                 for document_id in record["documentids"]:
@@ -230,14 +230,14 @@ class redactionsummary():
         return {"range": f"{min_stitched_page} - {max_stitched_page}" if min_stitched_page != max_stitched_page else f"{min_stitched_page}", "flagged_range":ranges}
     
 
-    def assignfullpagesections(self, redactionlayerid, mapped_flags):
+    def assignfullpagesections(self, redactionlayerid, mapped_flags, doc_conn=None):
         start_time = time.time()
         document_pages= self.get_sorted_original_pages_by_docid(mapped_flags)
         if not document_pages:
             logging.info(f"[PERF] DTS assignfullpagesections docs=0 elapsed={time.time() - start_time:.3f}s")
             return
 
-        docpagesections = documentpageflag().getsections_batch(redactionlayerid, document_pages)
+        docpagesections = documentpageflag().getsections_batch(redactionlayerid, document_pages, conn=doc_conn)
         sections_by_doc_page = defaultdict(list)
         for section in docpagesections:
             sections_by_doc_page[(section["documentid"], section["pageno"])].extend(
@@ -482,15 +482,15 @@ class redactionsummary():
         return formatted_section_list
 
     
-    def __getredactionlayerid(self, message):
+    def __getredactionlayerid(self, message, doc_conn=None):
         if message.category == "responsepackage" or "responsepackage_phase" in message.category:
-            return documentpageflag().getrecentredactionlayerid(message.ministryrequestid)
+            return documentpageflag().getrecentredactionlayerid(message.ministryrequestid, conn=doc_conn)
         elif message.category == "openinfo":
             return 1 # openinfo uses summary from redline layer
         return message.redactionlayerid 
 
-    def __getdeletedpages(self, ministryid, ordereddocids):
-        deletedpages = documentpageflag().getdeletedpages(ministryid, ordereddocids)
+    def __getdeletedpages(self, ministryid, ordereddocids, doc_conn=None):
+        deletedpages = documentpageflag().getdeletedpages(ministryid, ordereddocids, conn=doc_conn)
         documentpages = {}
         if deletedpages: 
             for entry in deletedpages:

--- a/computingservices/DocumentServices/services/dts/redactionsummary.py
+++ b/computingservices/DocumentServices/services/dts/redactionsummary.py
@@ -175,6 +175,8 @@ class redactionsummary():
             # print("pagecounts:",pagecounts)
             #document_pages = self.__get_document_pages(docpageflags)
             #original_pages = self.__adjust_original_pages(document_pages)
+            if pagecounts:
+                self.assignfullpagesections(redactionlayerid, mapped_flags)
             end_page = 0
             for record in records:
                 for document_id in record["documentids"]:
@@ -183,7 +185,6 @@ class redactionsummary():
                         record_range, total_page_count,end_page  = self.__createrecordpagerange(record, pagecounts, document_id, end_page)
                         # print(f"Range for each record- record_range:{record_range} &&& total_page_count:{total_page_count} \
                         #     &&& end_page-{end_page}")
-                        self.assignfullpagesections(redactionlayerid, mapped_flags)
                         # print("\nfilteredpages::",filteredpages)
                         range_result = self.__calculate_range(filteredpages, document_id)
                         recordwise_pagecount = next((record["pagecount"] for record in record_range if record["recordname"] == record['recordname'].upper()), 0)
@@ -232,16 +233,25 @@ class redactionsummary():
     def assignfullpagesections(self, redactionlayerid, mapped_flags):
         start_time = time.time()
         document_pages= self.get_sorted_original_pages_by_docid(mapped_flags)
-        # print("document_pages:",document_pages)
-        for item in document_pages:
-            for doc_id, pages in item.items():
-                docpagesections = documentpageflag().getsections_by_documentid_pageno(redactionlayerid, doc_id, pages)
-                # print(f"\n doc_id-{doc_id}, docpagesections-{docpagesections}")
-                for flag in mapped_flags:
-                        if flag['docid'] == doc_id and flag['flagid'] == 3:
-                            flag['sections']= self.__get_sections_mcf1(docpagesections, flag['dbpageno'])
-                            #self.__get_pagesection_mapping_cfd1(mapped_flags, docpagesections)
-        logging.info(f"[PERF] DTS assignfullpagesections docs={len(document_pages)} elapsed={time.time() - start_time:.3f}s")
+        if not document_pages:
+            logging.info(f"[PERF] DTS assignfullpagesections docs=0 elapsed={time.time() - start_time:.3f}s")
+            return
+
+        docpagesections = documentpageflag().getsections_batch(redactionlayerid, document_pages)
+        sections_by_doc_page = defaultdict(list)
+        for section in docpagesections:
+            sections_by_doc_page[(section["documentid"], section["pageno"])].extend(
+                [value.strip() for value in section["section"].split(",")]
+            )
+
+        for flag in mapped_flags:
+            if flag["flagid"] == 3:
+                flag["sections"] = list(filter(None, sections_by_doc_page[(flag["docid"], flag["dbpageno"])]))
+
+        logging.info(
+            f"[PERF] DTS assignfullpagesections docs={len(document_pages)} "
+            f"flags={len(mapped_flags)} elapsed={time.time() - start_time:.3f}s"
+        )
 
     def __get_sections_mcf1(self, docpagesections, pageno):
         sections = []
@@ -265,13 +275,7 @@ class redactionsummary():
 
             pages_by_docid[docid].append(original_page)
 
-        # Sort the original pages for each docid
-        for docid in pages_by_docid:
-            pages_by_docid[docid].sort()
-
-        # Convert to the desired format
-        result = [{docid: pages} for docid, pages in pages_by_docid.items()]
-        return result
+        return {docid: sorted(set(pages)) for docid, pages in pages_by_docid.items()}
 
     def __createrecordpagerange(self, record, pagecounts, doc_id, previous_end_page=0):
         total_page_count = pagecounts[doc_id]
@@ -629,4 +633,3 @@ class redactionsummary():
         for entry in data:
             totalpages=totalpages+data[entry]['pagecount']
         return totalpages
-

--- a/computingservices/DocumentServices/services/dts/redactionsummary.py
+++ b/computingservices/DocumentServices/services/dts/redactionsummary.py
@@ -591,6 +591,12 @@ class redactionsummary():
             entry["consults"] = docpageconsults[entry['originalpageno']] if entry['originalpageno'] in docpageconsults else None
         return docpages
 
+    def __get_pagesection_mapping_from_index(self, docpages, sections_by_pageno, docpageconsults):
+        for entry in docpages:
+            entry["sections"] = sections_by_pageno.get(entry['originalpageno'], [])
+            entry["consults"] = docpageconsults[entry['originalpageno']] if entry['originalpageno'] in docpageconsults else None
+        return docpages
+
     def __assign_batched_pagesections(self, redactionlayerid, document_pages, pending_mappings, doc_conn=None):
         if not pending_mappings:
             return
@@ -604,17 +610,17 @@ class redactionsummary():
             return
 
         all_sections = documentpageflag().getsections_batch(redactionlayerid, document_pages, conn=doc_conn)
-        sections_by_docid = defaultdict(list)
+        sections_by_docid = defaultdict(lambda: defaultdict(list))
         for section in all_sections:
-            sections_by_docid[section["documentid"]].append({
-                "pageno": section["pageno"],
-                "section": section["section"],
-            })
+            for value in section["section"].split(","):
+                cleaned = value.strip()
+                if cleaned:
+                    sections_by_docid[section["documentid"]][section["pageno"]].append(cleaned)
 
         for mapping in pending_mappings:
             mapping["pageflag"]["docpageflags"] = (
                 mapping["pageflag"]["docpageflags"]
-                + self.__get_pagesection_mapping(
+                + self.__get_pagesection_mapping_from_index(
                     mapping["filteredpages"],
                     sections_by_docid[mapping["docid"]],
                     mapping["docpageconsults"],

--- a/computingservices/DocumentServices/services/dts/redactionsummary.py
+++ b/computingservices/DocumentServices/services/dts/redactionsummary.py
@@ -69,6 +69,8 @@ class redactionsummary():
             skippages= []     
             pagecount = 0
             try:
+                section_document_pages = defaultdict(list)
+                pending_section_mappings = []
                 for docid in ordereddocids:
                     if docid in documentids:
                         docdeletedpages = deletedpages[docid] if docid in deletedpages else []
@@ -90,9 +92,14 @@ class redactionsummary():
                                 print("\nfilteredpages:",filteredpages)
                                 if len(filteredpages) > 0:
                                     originalpagenos = [pg['originalpageno'] for pg in filteredpages]
-                                    docpagesections = documentpageflag().getsections_by_documentid_pageno(redactionlayerid, docid, originalpagenos, conn=doc_conn)
+                                    section_document_pages[docid].extend(originalpagenos)
                                     docpageconsults = self.__get_consults_by_pageno(programareas, docpageflag["pageflag"], filteredpages)
-                                    pageflag['docpageflags'] = pageflag['docpageflags'] + self.__get_pagesection_mapping(filteredpages, docpagesections, docpageconsults)
+                                    pending_section_mappings.append({
+                                        "docid": docid,
+                                        "pageflag": pageflag,
+                                        "filteredpages": filteredpages,
+                                        "docpageconsults": docpageconsults,
+                                    })
                             skippages = self.__get_skippagenos(docpageflag['pageflag'], message.category, docdeletedpages, pageswithphases,pageswithnoflags)
                         elif docid not in docpageflags.keys() or len(docpageflags[docid]["pageflag"]) == 0:
                             # to handle scenarios in phased release packages where documents will have no page flags at all (either empty pageflag array or no pageflag property)
@@ -100,6 +107,12 @@ class redactionsummary():
                                 skippages = [x for x in range(1, stitchedpagedata[docid]["pagecount"]+1)]
                     if stitchedpagedata is not None:
                         pagecount = (pagecount+stitchedpagedata[docid]["pagecount"])-len(skippages)
+                self.__assign_batched_pagesections(
+                    redactionlayerid,
+                    section_document_pages,
+                    pending_section_mappings,
+                    doc_conn=doc_conn,
+                )
                 print("\n_pageflags1",_pageflags)
                 for pageflag in _pageflags:
                     _data = {}
@@ -577,6 +590,36 @@ class redactionsummary():
             entry["sections"] = self.__get_sections(docpagesections, entry['originalpageno'])
             entry["consults"] = docpageconsults[entry['originalpageno']] if entry['originalpageno'] in docpageconsults else None
         return docpages
+
+    def __assign_batched_pagesections(self, redactionlayerid, document_pages, pending_mappings, doc_conn=None):
+        if not pending_mappings:
+            return
+
+        document_pages = {
+            docid: sorted(set(pages))
+            for docid, pages in document_pages.items()
+            if pages
+        }
+        if not document_pages:
+            return
+
+        all_sections = documentpageflag().getsections_batch(redactionlayerid, document_pages, conn=doc_conn)
+        sections_by_docid = defaultdict(list)
+        for section in all_sections:
+            sections_by_docid[section["documentid"]].append({
+                "pageno": section["pageno"],
+                "section": section["section"],
+            })
+
+        for mapping in pending_mappings:
+            mapping["pageflag"]["docpageflags"] = (
+                mapping["pageflag"]["docpageflags"]
+                + self.__get_pagesection_mapping(
+                    mapping["filteredpages"],
+                    sections_by_docid[mapping["docid"]],
+                    mapping["docpageconsults"],
+                )
+            )
     
     
     def __get_sections(self, docpagesections, pageno):

--- a/computingservices/DocumentServices/services/redactionsummaryservice.py
+++ b/computingservices/DocumentServices/services/redactionsummaryservice.py
@@ -9,6 +9,7 @@ from services.dts.redactionsummary import redactionsummary
 from services.dal.documentpageflag import documentpageflag
 from rstreamio.message.schemas.redactionsummary import get_in_redactionsummary_msg, get_in_summary_object,get_in_summarypackage_object
 from services.dal.documenttemplate import documenttemplate
+from utils import getdbconnection, getfoidbconnection
 
 class redactionsummaryservice():
 
@@ -16,12 +17,16 @@ class redactionsummaryservice():
         start_total = time.time()
         summaryfilestozip = []
         message = get_in_redactionsummary_msg(incomingmessage)
+        doc_conn = None
+        foi_conn = None
         print('\n 1. get_in_redactionsummary_msg is : {0}'.format(message))
         try:
             category = message.category 
             #Condition to handle consults packaages (no summary files to be created)
             if category == "consultpackage": 
                 return summaryfilestozip
+            doc_conn = getdbconnection()
+            foi_conn = getfoidbconnection()
             pdfstitchjobactivity().recordjobstatus(message,3,"redactionsummarystarted")                      
             summarymsg = message.summarydocuments
             #Condition for handling oipcredline category
@@ -34,12 +39,12 @@ class redactionsummaryservice():
             print('\n 2. documenttypename', documenttypename)
             upload_responses=[]
             start_pageflags = time.time()
-            pageflags = self.__get_pageflags(category)
+            pageflags = self.__get_pageflags(category, doc_conn=doc_conn)
             elapsed_pageflags = time.time() - start_pageflags
             logging.info(f"[PERF] redactionsummaryservice.__get_pageflags category={category} elapsed={elapsed_pageflags:.3f}s")
 
             start_progareas = time.time()
-            programareas = documentpageflag().get_all_programareas()
+            programareas = documentpageflag().get_all_programareas(conn=foi_conn)
             elapsed_progareas = time.time() - start_progareas
             logging.info(f"[PERF] redactionsummaryservice.get_all_programareas elapsed={elapsed_progareas:.3f}s")
 
@@ -64,7 +69,7 @@ class redactionsummaryservice():
                     if not documentids:
                         continue
                     start_prepare = time.time()
-                    formattedsummary = redactionsummary().prepareredactionsummary(message, documentids, pageflags, programareas)
+                    formattedsummary = redactionsummary().prepareredactionsummary(message, documentids, pageflags, programareas, doc_conn=doc_conn)
                     elapsed_prepare = time.time() - start_prepare
                     logging.info(f"[PERF] redactionsummaryservice prepareredactionsummary divisionid={divisionid} docs={len(documentids)} elapsed={elapsed_prepare:.3f}s")
 
@@ -124,6 +129,11 @@ class redactionsummaryservice():
             print('error occured in redaction summary service: ', error)
             pdfstitchjobactivity().recordjobstatus(message,4,"redactionsummaryfailed",str(error),"summary generation failed")
             return summaryfilestozip
+        finally:
+            if foi_conn is not None:
+                foi_conn.close()
+            if doc_conn is not None:
+                doc_conn.close()
         
     def __get_summaryfilename(self, requestnumber, category, divisionname, stitcheddocfilename, phase):
         stitchedfilepath = stitcheddocfilename[:stitcheddocfilename.rfind( '/')+1]
@@ -145,10 +155,10 @@ class redactionsummaryservice():
         # print("---->",stitchedfilepath+_filename+" - summary.pdf")   
         return stitchedfilepath+_filename+" - summary.pdf"
   
-    def __get_pageflags(self, category):
+    def __get_pageflags(self, category, doc_conn=None):
         if category in ("responsepackage", "openinfo"):            
-            return documentpageflag().get_all_pageflags(['Consult', 'Not Responsive', 'Duplicate', 'Phase'])
-        return documentpageflag().get_all_pageflags(['Consult', 'Phase'])
+            return documentpageflag().get_all_pageflags(['Consult', 'Not Responsive', 'Duplicate', 'Phase'], conn=doc_conn)
+        return documentpageflag().get_all_pageflags(['Consult', 'Phase'], conn=doc_conn)
         
 
    

--- a/computingservices/DocumentServices/unittests/redactionsummary_test_utils.py
+++ b/computingservices/DocumentServices/unittests/redactionsummary_test_utils.py
@@ -1,0 +1,57 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+REDACTION_SUMMARY_PATH = Path(__file__).resolve().parents[1] / "services" / "dts" / "redactionsummary.py"
+
+
+def load_redactionsummary_module(module_name, fake_documentpageflag):
+    for name in [
+        module_name,
+        "services",
+        "services.dal",
+        "services.dal.documentpageflag",
+        "rstreamio",
+        "rstreamio.message",
+        "rstreamio.message.schemas",
+        "rstreamio.message.schemas.redactionsummary",
+    ]:
+        sys.modules.pop(name, None)
+
+    services_pkg = types.ModuleType("services")
+    services_pkg.__path__ = []
+    sys.modules["services"] = services_pkg
+
+    services_dal_pkg = types.ModuleType("services.dal")
+    services_dal_pkg.__path__ = []
+    sys.modules["services.dal"] = services_dal_pkg
+
+    documentpageflag_module = types.ModuleType("services.dal.documentpageflag")
+    documentpageflag_module.documentpageflag = fake_documentpageflag
+    sys.modules["services.dal.documentpageflag"] = documentpageflag_module
+
+    rstreamio_pkg = types.ModuleType("rstreamio")
+    rstreamio_pkg.__path__ = []
+    sys.modules["rstreamio"] = rstreamio_pkg
+
+    message_pkg = types.ModuleType("rstreamio.message")
+    message_pkg.__path__ = []
+    sys.modules["rstreamio.message"] = message_pkg
+
+    schemas_pkg = types.ModuleType("rstreamio.message.schemas")
+    schemas_pkg.__path__ = []
+    sys.modules["rstreamio.message.schemas"] = schemas_pkg
+
+    schema_module = types.ModuleType("rstreamio.message.schemas.redactionsummary")
+    schema_module.get_in_summary_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
+    schema_module.get_in_summarypackage_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
+    sys.modules["rstreamio.message.schemas.redactionsummary"] = schema_module
+
+    spec = importlib.util.spec_from_file_location(module_name, REDACTION_SUMMARY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
+++ b/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
@@ -5,60 +5,16 @@ import types
 import unittest
 from pathlib import Path
 
+from unittests.redactionsummary_test_utils import load_redactionsummary_module
 
-REDACTION_SUMMARY_PATH = Path(__file__).resolve().parents[1] / "services" / "dts" / "redactionsummary.py"
 DOCUMENT_PAGE_FLAG_PATH = Path(__file__).resolve().parents[1] / "services" / "dal" / "documentpageflag.py"
 
 
 def _load_redactionsummary_module(fake_documentpageflag):
-    module_name = "DocumentServices.services.dts.redactionsummary_batch_under_test"
-
-    for name in [
-        module_name,
-        "services",
-        "services.dal",
-        "services.dal.documentpageflag",
-        "rstreamio",
-        "rstreamio.message",
-        "rstreamio.message.schemas",
-        "rstreamio.message.schemas.redactionsummary",
-    ]:
-        sys.modules.pop(name, None)
-
-    services_pkg = types.ModuleType("services")
-    services_pkg.__path__ = []
-    sys.modules["services"] = services_pkg
-
-    services_dal_pkg = types.ModuleType("services.dal")
-    services_dal_pkg.__path__ = []
-    sys.modules["services.dal"] = services_dal_pkg
-
-    documentpageflag_module = types.ModuleType("services.dal.documentpageflag")
-    documentpageflag_module.documentpageflag = fake_documentpageflag
-    sys.modules["services.dal.documentpageflag"] = documentpageflag_module
-
-    rstreamio_pkg = types.ModuleType("rstreamio")
-    rstreamio_pkg.__path__ = []
-    sys.modules["rstreamio"] = rstreamio_pkg
-
-    message_pkg = types.ModuleType("rstreamio.message")
-    message_pkg.__path__ = []
-    sys.modules["rstreamio.message"] = message_pkg
-
-    schemas_pkg = types.ModuleType("rstreamio.message.schemas")
-    schemas_pkg.__path__ = []
-    sys.modules["rstreamio.message.schemas"] = schemas_pkg
-
-    schema_module = types.ModuleType("rstreamio.message.schemas.redactionsummary")
-    schema_module.get_in_summary_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
-    schema_module.get_in_summarypackage_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
-    sys.modules["rstreamio.message.schemas.redactionsummary"] = schema_module
-
-    spec = importlib.util.spec_from_file_location(module_name, REDACTION_SUMMARY_PATH)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
+    return load_redactionsummary_module(
+        "DocumentServices.services.dts.redactionsummary_batch_under_test",
+        fake_documentpageflag,
+    )
 
 
 def _load_documentpageflag_module(fake_connection):
@@ -209,6 +165,85 @@ class RedactionSummaryBatchSectionTests(unittest.TestCase):
 
         self.assertEqual(1, CountingRedactionSummary.assign_calls)
         self.assertEqual("MCF-2026-0001", result["requestnumber"])
+
+    def test_non_mcf_responsepackage_uses_one_batch_section_query(self):
+        class FakeDocumentPageFlag:
+            batch_calls = []
+            single_calls = []
+
+            def getrecentredactionlayerid(self, ministryrequestid, conn=None):
+                return 99
+
+            def getpagecount_by_documentid(self, ministryrequestid, documentids, conn=None):
+                return {
+                    10: {"pagecount": 2},
+                    20: {"pagecount": 2},
+                }
+
+            def get_documentpageflag(self, ministryrequestid, redactionlayerid, documentids, conn=None):
+                return {
+                    10: {
+                        "pageflag": [
+                            {"page": 1, "flagid": 1},
+                            {"page": 2, "flagid": 2},
+                        ],
+                        "attributes": {},
+                    },
+                    20: {
+                        "pageflag": [
+                            {"page": 1, "flagid": 1},
+                            {"page": 2, "flagid": 2},
+                        ],
+                        "attributes": {},
+                    },
+                }
+
+            def getdeletedpages(self, ministryrequestid, docids, conn=None):
+                return []
+
+            def getsections_batch(self, redactionlayerid, document_pages, conn=None):
+                type(self).batch_calls.append((redactionlayerid, document_pages, conn))
+                return [
+                    {"documentid": 10, "pageno": 0, "section": "22"},
+                    {"documentid": 10, "pageno": 1, "section": "15"},
+                    {"documentid": 20, "pageno": 0, "section": "13"},
+                    {"documentid": 20, "pageno": 1, "section": "21"},
+                ]
+
+            def getsections_by_documentid_pageno(self, redactionlayerid, documentid, pagenos, conn=None):
+                type(self).single_calls.append((redactionlayerid, documentid, pagenos, conn))
+                return []
+
+        module = _load_redactionsummary_module(FakeDocumentPageFlag)
+        message = types.SimpleNamespace(
+            bcgovcode="EDU",
+            requesttype="general",
+            category="responsepackage",
+            ministryrequestid=500,
+            requestnumber="EDU-2026-0001",
+            redactionlayerid=7,
+            phase=None,
+            summarydocuments=json.dumps(
+                {
+                    "sorteddocuments": [10, 20],
+                    "pkgdocuments": [{"divisionid": 1, "documentids": [10, 20]}],
+                }
+            ),
+        )
+        pageflags = [
+            {"pageflagid": 1, "name": "Full Disclosure", "description": "Full Disclosure"},
+            {"pageflagid": 2, "name": "Partial Disclosure", "description": "Partial Disclosure"},
+        ]
+        doc_conn = object()
+
+        result = module.redactionsummary().prepareredactionsummary(
+            message, [10, 20], pageflags, {}, doc_conn=doc_conn
+        )
+
+        self.assertEqual([(99, {10: [0, 1], 20: [0, 1]}, doc_conn)], FakeDocumentPageFlag.batch_calls)
+        self.assertEqual([], FakeDocumentPageFlag.single_calls)
+        self.assertEqual("EDU-2026-0001", result["requestnumber"])
+        self.assertEqual(4, len(result["data"]))
 
 
 if __name__ == "__main__":

--- a/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
+++ b/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
@@ -79,6 +79,30 @@ class RedactionSummaryBatchSectionTests(unittest.TestCase):
         self.assertIn("unnest(%s::integer[], %s::integer[])", FakeCursor.executed_sql)
         self.assertEqual(([10, 10, 20], [0, 1, 2], 99), FakeCursor.executed_params)
 
+    def test_getsections_batch_closes_cursor_when_query_fails(self):
+        class FakeCursor:
+            closed = False
+
+            def execute(self, sql, params):
+                raise RuntimeError("query failed")
+
+            def close(self):
+                type(self).closed = True
+
+        class FakeConnection:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                return None
+
+        module = _load_documentpageflag_module(FakeConnection())
+
+        with self.assertRaises(RuntimeError):
+            module.documentpageflag.getsections_batch(99, {10: [0]})
+
+        self.assertTrue(FakeCursor.closed)
+
     def test_assignfullpagesections_uses_one_batch_query_for_all_documents(self):
         class FakeDocumentPageFlag:
             batch_calls = []

--- a/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
+++ b/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
@@ -1,0 +1,215 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+REDACTION_SUMMARY_PATH = Path(__file__).resolve().parents[1] / "services" / "dts" / "redactionsummary.py"
+DOCUMENT_PAGE_FLAG_PATH = Path(__file__).resolve().parents[1] / "services" / "dal" / "documentpageflag.py"
+
+
+def _load_redactionsummary_module(fake_documentpageflag):
+    module_name = "DocumentServices.services.dts.redactionsummary_batch_under_test"
+
+    for name in [
+        module_name,
+        "services",
+        "services.dal",
+        "services.dal.documentpageflag",
+        "rstreamio",
+        "rstreamio.message",
+        "rstreamio.message.schemas",
+        "rstreamio.message.schemas.redactionsummary",
+    ]:
+        sys.modules.pop(name, None)
+
+    services_pkg = types.ModuleType("services")
+    services_pkg.__path__ = []
+    sys.modules["services"] = services_pkg
+
+    services_dal_pkg = types.ModuleType("services.dal")
+    services_dal_pkg.__path__ = []
+    sys.modules["services.dal"] = services_dal_pkg
+
+    documentpageflag_module = types.ModuleType("services.dal.documentpageflag")
+    documentpageflag_module.documentpageflag = fake_documentpageflag
+    sys.modules["services.dal.documentpageflag"] = documentpageflag_module
+
+    rstreamio_pkg = types.ModuleType("rstreamio")
+    rstreamio_pkg.__path__ = []
+    sys.modules["rstreamio"] = rstreamio_pkg
+
+    message_pkg = types.ModuleType("rstreamio.message")
+    message_pkg.__path__ = []
+    sys.modules["rstreamio.message"] = message_pkg
+
+    schemas_pkg = types.ModuleType("rstreamio.message.schemas")
+    schemas_pkg.__path__ = []
+    sys.modules["rstreamio.message.schemas"] = schemas_pkg
+
+    schema_module = types.ModuleType("rstreamio.message.schemas.redactionsummary")
+    schema_module.get_in_summary_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
+    schema_module.get_in_summarypackage_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
+    sys.modules["rstreamio.message.schemas.redactionsummary"] = schema_module
+
+    spec = importlib.util.spec_from_file_location(module_name, REDACTION_SUMMARY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_documentpageflag_module(fake_connection):
+    module_name = "DocumentServices.services.dal.documentpageflag_batch_under_test"
+
+    for name in [
+        module_name,
+        "utils",
+    ]:
+        sys.modules.pop(name, None)
+
+    utils_module = types.ModuleType("utils")
+    utils_module.getdbconnection = lambda: fake_connection
+    utils_module.getfoidbconnection = lambda: fake_connection
+    sys.modules["utils"] = utils_module
+
+    spec = importlib.util.spec_from_file_location(module_name, DOCUMENT_PAGE_FLAG_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class RedactionSummaryBatchSectionTests(unittest.TestCase):
+    def test_getsections_batch_uses_annotation_type_and_exact_document_page_pairs(self):
+        class FakeCursor:
+            executed_sql = None
+            executed_params = None
+
+            def execute(self, sql, params):
+                type(self).executed_sql = sql
+                type(self).executed_params = params
+
+            def fetchall(self):
+                return [(10, 0, "22, 15"), (20, 2, "13")]
+
+            def close(self):
+                return None
+
+        class FakeConnection:
+            closed = False
+
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                type(self).closed = True
+
+        module = _load_documentpageflag_module(FakeConnection())
+
+        sections = module.documentpageflag.getsections_batch(99, {10: [1, 0, 0], 20: [2]})
+
+        self.assertEqual(
+            [
+                {"documentid": 10, "pageno": 0, "section": "22, 15"},
+                {"documentid": 20, "pageno": 2, "section": "13"},
+            ],
+            sections,
+        )
+        self.assertIn("a.annotationtype = 'freetext'", FakeCursor.executed_sql)
+        self.assertNotIn("annotation LIKE", FakeCursor.executed_sql)
+        self.assertIn("unnest(%s::integer[], %s::integer[])", FakeCursor.executed_sql)
+        self.assertEqual(([10, 10, 20], [0, 1, 2], 99), FakeCursor.executed_params)
+
+    def test_assignfullpagesections_uses_one_batch_query_for_all_documents(self):
+        class FakeDocumentPageFlag:
+            batch_calls = []
+            single_calls = []
+
+            def getsections_batch(self, redactionlayerid, document_pages):
+                type(self).batch_calls.append((redactionlayerid, document_pages))
+                return [
+                    {"documentid": 10, "pageno": 0, "section": "22, 15"},
+                    {"documentid": 20, "pageno": 2, "section": "13"},
+                ]
+
+            def getsections_by_documentid_pageno(self, redactionlayerid, documentid, pagenos):
+                type(self).single_calls.append((redactionlayerid, documentid, pagenos))
+                return []
+
+        module = _load_redactionsummary_module(FakeDocumentPageFlag)
+        summary = module.redactionsummary()
+        mapped_flags = [
+            {"docid": 10, "dbpageno": 0, "originalpageno": 1, "stitchedpageno": 1, "flagid": 3},
+            {"docid": 10, "dbpageno": 1, "originalpageno": 2, "stitchedpageno": 2, "flagid": 4},
+            {"docid": 20, "dbpageno": 2, "originalpageno": 3, "stitchedpageno": 3, "flagid": 3},
+        ]
+
+        summary.assignfullpagesections(99, mapped_flags)
+
+        self.assertEqual([(99, {10: [0, 1], 20: [2]})], FakeDocumentPageFlag.batch_calls)
+        self.assertEqual([], FakeDocumentPageFlag.single_calls)
+        self.assertEqual(["22", "15"], mapped_flags[0]["sections"])
+        self.assertNotIn("sections", mapped_flags[1])
+        self.assertEqual(["13"], mapped_flags[2]["sections"])
+
+    def test_mcf_personal_summary_assigns_full_page_sections_once(self):
+        class FakeDocumentPageFlag:
+            def getrecentredactionlayerid(self, ministryrequestid):
+                return 99
+
+            def getpagecount_by_documentid(self, ministryrequestid, documentids):
+                return {10: {"pagecount": 1}, 20: {"pagecount": 1}}
+
+            def get_documentpageflag(self, ministryrequestid, redactionlayerid, documentids):
+                return {
+                    10: {"pageflag": [{"page": 1, "flagid": 3}], "attributes": {}},
+                    20: {"pageflag": [{"page": 1, "flagid": 3}], "attributes": {}},
+                }
+
+            def getdeletedpages(self, ministryrequestid, docids):
+                return []
+
+        module = _load_redactionsummary_module(FakeDocumentPageFlag)
+
+        class CountingRedactionSummary(module.redactionsummary):
+            assign_calls = 0
+
+            def assignfullpagesections(self, redactionlayerid, mapped_flags):
+                type(self).assign_calls += 1
+                for flag in mapped_flags:
+                    if flag["flagid"] == 3:
+                        flag["sections"] = ["22"]
+
+        message = types.SimpleNamespace(
+            bcgovcode="mcf",
+            requesttype="personal",
+            category="responsepackage",
+            ministryrequestid=500,
+            requestnumber="MCF-2026-0001",
+            phase=None,
+            summarydocuments=json.dumps(
+                {
+                    "sorteddocuments": [10, 20],
+                    "pkgdocuments": [
+                        {
+                            "records": [
+                                {"recordname": "record a", "documentids": [10]},
+                                {"recordname": "record b", "documentids": [20]},
+                            ]
+                        }
+                    ],
+                }
+            ),
+        )
+
+        result = CountingRedactionSummary().prepareredactionsummary(message, [10, 20], [], {})
+
+        self.assertEqual(1, CountingRedactionSummary.assign_calls)
+        self.assertEqual("MCF-2026-0001", result["requestnumber"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
+++ b/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
@@ -128,14 +128,14 @@ class RedactionSummaryBatchSectionTests(unittest.TestCase):
             batch_calls = []
             single_calls = []
 
-            def getsections_batch(self, redactionlayerid, document_pages):
+            def getsections_batch(self, redactionlayerid, document_pages, conn=None):
                 type(self).batch_calls.append((redactionlayerid, document_pages))
                 return [
                     {"documentid": 10, "pageno": 0, "section": "22, 15"},
                     {"documentid": 20, "pageno": 2, "section": "13"},
                 ]
 
-            def getsections_by_documentid_pageno(self, redactionlayerid, documentid, pagenos):
+            def getsections_by_documentid_pageno(self, redactionlayerid, documentid, pagenos, conn=None):
                 type(self).single_calls.append((redactionlayerid, documentid, pagenos))
                 return []
 
@@ -157,19 +157,19 @@ class RedactionSummaryBatchSectionTests(unittest.TestCase):
 
     def test_mcf_personal_summary_assigns_full_page_sections_once(self):
         class FakeDocumentPageFlag:
-            def getrecentredactionlayerid(self, ministryrequestid):
+            def getrecentredactionlayerid(self, ministryrequestid, conn=None):
                 return 99
 
-            def getpagecount_by_documentid(self, ministryrequestid, documentids):
+            def getpagecount_by_documentid(self, ministryrequestid, documentids, conn=None):
                 return {10: {"pagecount": 1}, 20: {"pagecount": 1}}
 
-            def get_documentpageflag(self, ministryrequestid, redactionlayerid, documentids):
+            def get_documentpageflag(self, ministryrequestid, redactionlayerid, documentids, conn=None):
                 return {
                     10: {"pageflag": [{"page": 1, "flagid": 3}], "attributes": {}},
                     20: {"pageflag": [{"page": 1, "flagid": 3}], "attributes": {}},
                 }
 
-            def getdeletedpages(self, ministryrequestid, docids):
+            def getdeletedpages(self, ministryrequestid, docids, conn=None):
                 return []
 
         module = _load_redactionsummary_module(FakeDocumentPageFlag)
@@ -177,7 +177,7 @@ class RedactionSummaryBatchSectionTests(unittest.TestCase):
         class CountingRedactionSummary(module.redactionsummary):
             assign_calls = 0
 
-            def assignfullpagesections(self, redactionlayerid, mapped_flags):
+            def assignfullpagesections(self, redactionlayerid, mapped_flags, doc_conn=None):
                 type(self).assign_calls += 1
                 for flag in mapped_flags:
                     if flag["flagid"] == 3:

--- a/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
+++ b/computingservices/DocumentServices/unittests/test_redactionsummary_batch_sections.py
@@ -245,6 +245,66 @@ class RedactionSummaryBatchSectionTests(unittest.TestCase):
         self.assertEqual("EDU-2026-0001", result["requestnumber"])
         self.assertEqual(4, len(result["data"]))
 
+    def test_batched_pagesections_are_indexed_by_page_before_mapping(self):
+        class FakeDocumentPageFlag:
+            def getsections_batch(self, redactionlayerid, document_pages, conn=None):
+                return [
+                    {"documentid": 10, "pageno": 0, "section": "22"},
+                    {"documentid": 10, "pageno": 0, "section": "15"},
+                    {"documentid": 10, "pageno": 1, "section": "13"},
+                ]
+
+        module = _load_redactionsummary_module(FakeDocumentPageFlag)
+        summary = module.redactionsummary()
+
+        def fail_if_linear_scan_is_used(*args, **kwargs):
+            raise AssertionError("batched section mapping should use a page index")
+
+        summary._redactionsummary__get_sections = fail_if_linear_scan_is_used
+        pageflag = {"docpageflags": []}
+        pending_mappings = [
+            {
+                "docid": 10,
+                "pageflag": pageflag,
+                "filteredpages": [
+                    {"originalpageno": 0, "stitchedpageno": 1},
+                    {"originalpageno": 1, "stitchedpageno": 2},
+                    {"originalpageno": 2, "stitchedpageno": 3},
+                ],
+                "docpageconsults": {1: "IAO"},
+            }
+        ]
+
+        summary._redactionsummary__assign_batched_pagesections(
+            99,
+            {10: [0, 1, 2]},
+            pending_mappings,
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "originalpageno": 0,
+                    "stitchedpageno": 1,
+                    "sections": ["22", "15"],
+                    "consults": None,
+                },
+                {
+                    "originalpageno": 1,
+                    "stitchedpageno": 2,
+                    "sections": ["13"],
+                    "consults": "IAO",
+                },
+                {
+                    "originalpageno": 2,
+                    "stitchedpageno": 3,
+                    "sections": [],
+                    "consults": None,
+                },
+            ],
+            pageflag["docpageflags"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/computingservices/DocumentServices/unittests/test_redactionsummary_connection_reuse.py
+++ b/computingservices/DocumentServices/unittests/test_redactionsummary_connection_reuse.py
@@ -1,0 +1,196 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+DOCUMENT_PAGE_FLAG_PATH = Path(__file__).resolve().parents[1] / "services" / "dal" / "documentpageflag.py"
+REDACTION_SUMMARY_PATH = Path(__file__).resolve().parents[1] / "services" / "dts" / "redactionsummary.py"
+
+
+class FakeCursor:
+    def __init__(self, rows):
+        self.rows = rows
+        self.closed = False
+
+    def execute(self, sql, params=None):
+        self.sql = sql
+        self.params = params
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConnection:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.closed = False
+        self.cursors = []
+
+    def cursor(self):
+        cursor = FakeCursor(self.rows)
+        self.cursors.append(cursor)
+        return cursor
+
+    def close(self):
+        self.closed = True
+
+
+def load_documentpageflag_module(created_connections):
+    module_name = "DocumentServices.services.dal.documentpageflag_connection_reuse_under_test"
+    for name in [module_name, "utils"]:
+        sys.modules.pop(name, None)
+
+    def getdbconnection():
+        conn = FakeConnection([(1, "Full Disclosure", "Full Disclosure")])
+        created_connections.append(conn)
+        return conn
+
+    utils_module = types.ModuleType("utils")
+    utils_module.getdbconnection = getdbconnection
+    utils_module.getfoidbconnection = getdbconnection
+    sys.modules["utils"] = utils_module
+
+    spec = importlib.util.spec_from_file_location(module_name, DOCUMENT_PAGE_FLAG_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_redactionsummary_module(fake_documentpageflag):
+    module_name = "DocumentServices.services.dts.redactionsummary_connection_reuse_under_test"
+    for name in [
+        module_name,
+        "services",
+        "services.dal",
+        "services.dal.documentpageflag",
+        "rstreamio",
+        "rstreamio.message",
+        "rstreamio.message.schemas",
+        "rstreamio.message.schemas.redactionsummary",
+    ]:
+        sys.modules.pop(name, None)
+
+    services_pkg = types.ModuleType("services")
+    services_pkg.__path__ = []
+    sys.modules["services"] = services_pkg
+
+    services_dal_pkg = types.ModuleType("services.dal")
+    services_dal_pkg.__path__ = []
+    sys.modules["services.dal"] = services_dal_pkg
+
+    documentpageflag_module = types.ModuleType("services.dal.documentpageflag")
+    documentpageflag_module.documentpageflag = fake_documentpageflag
+    sys.modules["services.dal.documentpageflag"] = documentpageflag_module
+
+    rstreamio_pkg = types.ModuleType("rstreamio")
+    rstreamio_pkg.__path__ = []
+    sys.modules["rstreamio"] = rstreamio_pkg
+
+    message_pkg = types.ModuleType("rstreamio.message")
+    message_pkg.__path__ = []
+    sys.modules["rstreamio.message"] = message_pkg
+
+    schemas_pkg = types.ModuleType("rstreamio.message.schemas")
+    schemas_pkg.__path__ = []
+    sys.modules["rstreamio.message.schemas"] = schemas_pkg
+
+    schema_module = types.ModuleType("rstreamio.message.schemas.redactionsummary")
+    schema_module.get_in_summary_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
+    schema_module.get_in_summarypackage_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
+    sys.modules["rstreamio.message.schemas.redactionsummary"] = schema_module
+
+    spec = importlib.util.spec_from_file_location(module_name, REDACTION_SUMMARY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class DocumentPageFlagConnectionReuseTests(unittest.TestCase):
+    def test_dal_does_not_close_caller_owned_connection(self):
+        created_connections = []
+        module = load_documentpageflag_module(created_connections)
+        caller_conn = FakeConnection([(1, "Full Disclosure", "Full Disclosure")])
+
+        result = module.documentpageflag.get_all_pageflags([], conn=caller_conn)
+
+        self.assertEqual([{"pageflagid": 1, "name": "Full Disclosure", "description": "Full Disclosure"}], result)
+        self.assertFalse(caller_conn.closed)
+        self.assertEqual([], created_connections)
+
+    def test_dal_closes_connection_it_creates(self):
+        created_connections = []
+        module = load_documentpageflag_module(created_connections)
+
+        module.documentpageflag.get_all_pageflags([])
+
+        self.assertEqual(1, len(created_connections))
+        self.assertTrue(created_connections[0].closed)
+
+
+class RedactionSummaryConnectionReuseTests(unittest.TestCase):
+    def test_redactionsummary_uses_caller_document_connection_for_dal_calls(self):
+        received_connections = []
+
+        class FakeDocumentPageFlag:
+            def getrecentredactionlayerid(self, ministryrequestid, conn=None):
+                received_connections.append(conn)
+                return 99
+
+            def getpagecount_by_documentid(self, ministryrequestid, documentids, conn=None):
+                received_connections.append(conn)
+                return {10: {"pagecount": 1}}
+
+            def getoriginalpagecount_by_documentid(self, ministryrequestid, documentids, conn=None):
+                received_connections.append(conn)
+                return {10: {"pagecount": 1}}
+
+            def get_documentpageflag(self, ministryrequestid, redactionlayerid, documentids, conn=None):
+                received_connections.append(conn)
+                return {10: {"pageflag": [{"page": 1, "flagid": 1}], "attributes": {}}}
+
+            def getdeletedpages(self, ministryrequestid, docids, conn=None):
+                received_connections.append(conn)
+                return []
+
+            def getsections_by_documentid_pageno(self, redactionlayerid, documentid, pagenos, conn=None):
+                received_connections.append(conn)
+                return [{"pageno": 0, "section": "22"}]
+
+        module = load_redactionsummary_module(FakeDocumentPageFlag)
+        sentinel_conn = object()
+        message = types.SimpleNamespace(
+            bcgovcode="EDU",
+            requesttype="general",
+            category="responsepackage",
+            ministryrequestid=500,
+            requestnumber="EDU-2026-0001",
+            redactionlayerid=7,
+            phase=None,
+            summarydocuments=json.dumps({"sorteddocuments": [10], "pkgdocuments": []}),
+        )
+
+        module.redactionsummary().prepareredactionsummary(
+            message,
+            [10],
+            [{"pageflagid": 1, "name": "Full Disclosure", "description": "Full Disclosure"}],
+            {},
+            doc_conn=sentinel_conn,
+        )
+
+        self.assertEqual(5, len(received_connections))
+        self.assertTrue(all(conn is sentinel_conn for conn in received_connections))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/computingservices/DocumentServices/unittests/test_redactionsummary_connection_reuse.py
+++ b/computingservices/DocumentServices/unittests/test_redactionsummary_connection_reuse.py
@@ -5,9 +5,10 @@ import types
 import unittest
 from pathlib import Path
 
+from unittests.redactionsummary_test_utils import load_redactionsummary_module as load_redactionsummary_with_fake_dal
+
 
 DOCUMENT_PAGE_FLAG_PATH = Path(__file__).resolve().parents[1] / "services" / "dal" / "documentpageflag.py"
-REDACTION_SUMMARY_PATH = Path(__file__).resolve().parents[1] / "services" / "dts" / "redactionsummary.py"
 
 
 class FakeCursor:
@@ -67,53 +68,10 @@ def load_documentpageflag_module(created_connections):
 
 
 def load_redactionsummary_module(fake_documentpageflag):
-    module_name = "DocumentServices.services.dts.redactionsummary_connection_reuse_under_test"
-    for name in [
-        module_name,
-        "services",
-        "services.dal",
-        "services.dal.documentpageflag",
-        "rstreamio",
-        "rstreamio.message",
-        "rstreamio.message.schemas",
-        "rstreamio.message.schemas.redactionsummary",
-    ]:
-        sys.modules.pop(name, None)
-
-    services_pkg = types.ModuleType("services")
-    services_pkg.__path__ = []
-    sys.modules["services"] = services_pkg
-
-    services_dal_pkg = types.ModuleType("services.dal")
-    services_dal_pkg.__path__ = []
-    sys.modules["services.dal"] = services_dal_pkg
-
-    documentpageflag_module = types.ModuleType("services.dal.documentpageflag")
-    documentpageflag_module.documentpageflag = fake_documentpageflag
-    sys.modules["services.dal.documentpageflag"] = documentpageflag_module
-
-    rstreamio_pkg = types.ModuleType("rstreamio")
-    rstreamio_pkg.__path__ = []
-    sys.modules["rstreamio"] = rstreamio_pkg
-
-    message_pkg = types.ModuleType("rstreamio.message")
-    message_pkg.__path__ = []
-    sys.modules["rstreamio.message"] = message_pkg
-
-    schemas_pkg = types.ModuleType("rstreamio.message.schemas")
-    schemas_pkg.__path__ = []
-    sys.modules["rstreamio.message.schemas"] = schemas_pkg
-
-    schema_module = types.ModuleType("rstreamio.message.schemas.redactionsummary")
-    schema_module.get_in_summary_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
-    schema_module.get_in_summarypackage_object = lambda payload: types.SimpleNamespace(**json.loads(payload))
-    sys.modules["rstreamio.message.schemas.redactionsummary"] = schema_module
-
-    spec = importlib.util.spec_from_file_location(module_name, REDACTION_SUMMARY_PATH)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
+    return load_redactionsummary_with_fake_dal(
+        "DocumentServices.services.dts.redactionsummary_connection_reuse_under_test",
+        fake_documentpageflag,
+    )
 
 
 class DocumentPageFlagConnectionReuseTests(unittest.TestCase):
@@ -136,6 +94,26 @@ class DocumentPageFlagConnectionReuseTests(unittest.TestCase):
 
         self.assertEqual(1, len(created_connections))
         self.assertTrue(created_connections[0].closed)
+
+    def test_getrecentredactionlayerid_returns_scalar_from_cursor_row(self):
+        created_connections = []
+        module = load_documentpageflag_module(created_connections)
+        caller_conn = FakeConnection([(42,)])
+
+        result = module.documentpageflag.getrecentredactionlayerid(500, conn=caller_conn)
+
+        self.assertEqual(42, result)
+        self.assertFalse(caller_conn.closed)
+
+    def test_getrecentredactionlayerid_defaults_when_no_row_returned(self):
+        created_connections = []
+        module = load_documentpageflag_module(created_connections)
+        caller_conn = FakeConnection([])
+
+        result = module.documentpageflag.getrecentredactionlayerid(500, conn=caller_conn)
+
+        self.assertEqual(1, result)
+        self.assertFalse(caller_conn.closed)
 
 
 class RedactionSummaryConnectionReuseTests(unittest.TestCase):
@@ -163,9 +141,9 @@ class RedactionSummaryConnectionReuseTests(unittest.TestCase):
                 received_connections.append(conn)
                 return []
 
-            def getsections_by_documentid_pageno(self, redactionlayerid, documentid, pagenos, conn=None):
+            def getsections_batch(self, redactionlayerid, document_pages, conn=None):
                 received_connections.append(conn)
-                return [{"pageno": 0, "section": "22"}]
+                return [{"documentid": 10, "pageno": 0, "section": "22"}]
 
         module = load_redactionsummary_module(FakeDocumentPageFlag)
         sentinel_conn = object()

--- a/computingservices/DocumentServices/unittests/test_redactionsummaryservice.py
+++ b/computingservices/DocumentServices/unittests/test_redactionsummaryservice.py
@@ -19,6 +19,7 @@ def _load_service_module():
         "services",
         "services.dal",
         "services.dts",
+        "utils",
         "rstreamio",
         "rstreamio.message",
         "rstreamio.message.schemas",
@@ -45,6 +46,33 @@ def _load_service_module():
     services_dts_pkg.__path__ = []
     sys.modules["services.dts"] = services_dts_pkg
 
+    class FakeConnection:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    fake_utils = types.ModuleType("utils")
+    fake_utils.doc_connection = None
+    fake_utils.foi_connection = None
+    fake_utils.doc_connection_count = 0
+    fake_utils.foi_connection_count = 0
+
+    def getdbconnection():
+        fake_utils.doc_connection_count += 1
+        fake_utils.doc_connection = FakeConnection()
+        return fake_utils.doc_connection
+
+    def getfoidbconnection():
+        fake_utils.foi_connection_count += 1
+        fake_utils.foi_connection = FakeConnection()
+        return fake_utils.foi_connection
+
+    fake_utils.getdbconnection = getdbconnection
+    fake_utils.getfoidbconnection = getfoidbconnection
+    sys.modules["utils"] = fake_utils
+
     rstreamio_pkg = types.ModuleType("rstreamio")
     rstreamio_pkg.__path__ = []
     sys.modules["rstreamio"] = rstreamio_pkg
@@ -70,9 +98,11 @@ def _load_service_module():
 
     class FakeRedactionSummary:
         calls = []
+        last_doc_conn = None
 
-        def prepareredactionsummary(self, message, documentids, pageflags, programareas):
+        def prepareredactionsummary(self, message, documentids, pageflags, programareas, doc_conn=None):
             type(self).calls.append(list(documentids))
+            type(self).last_doc_conn = doc_conn
             return {"requestnumber": message.requestnumber, "data": []}
 
     redactionsummary_module.redactionsummary = FakeRedactionSummary
@@ -109,10 +139,15 @@ def _load_service_module():
     documentpageflag_module = types.ModuleType("services.dal.documentpageflag")
 
     class FakeDocumentPageFlag:
+        last_pageflags_conn = None
+        last_programareas_conn = None
+
         def get_all_pageflags(self, *args, **kwargs):
+            type(self).last_pageflags_conn = kwargs.get("conn")
             return []
 
         def get_all_programareas(self, *args, **kwargs):
+            type(self).last_programareas_conn = kwargs.get("conn")
             return []
 
     documentpageflag_module.documentpageflag = FakeDocumentPageFlag
@@ -153,17 +188,20 @@ def _load_service_module():
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
-    return module, FakeDocumentTemplate, FakeRedactionSummary
+    return module, FakeDocumentTemplate, FakeRedactionSummary, FakeDocumentPageFlag, fake_utils
 
 
 class RedactionSummaryServiceTests(unittest.TestCase):
     def setUp(self):
-        self.module, self.documenttemplate, self.redactionsummary = _load_service_module()
+        self.module, self.documenttemplate, self.redactionsummary, self.documentpageflag, self.fake_utils = _load_service_module()
         self.documenttemplate.compatible_document_ids = []
         self.documenttemplate.record_group_document_ids = []
         self.documenttemplate.compatible_calls = []
         self.documenttemplate.record_group_calls = []
         self.redactionsummary.calls = []
+        self.redactionsummary.last_doc_conn = None
+        self.documentpageflag.last_pageflags_conn = None
+        self.documentpageflag.last_programareas_conn = None
 
     def test_filters_non_document_set_ids_before_generating_summary(self):
         self.documenttemplate.compatible_document_ids = [102432, 102439]
@@ -199,6 +237,45 @@ class RedactionSummaryServiceTests(unittest.TestCase):
         self.assertEqual([[102432, 102439]], self.redactionsummary.calls)
         self.assertEqual([[102432, 102433, 102439]], self.documenttemplate.compatible_calls)
         self.assertEqual([], self.documenttemplate.record_group_calls)
+
+    def test_reuses_one_document_and_foi_connection_for_summary_generation(self):
+        self.documenttemplate.compatible_document_ids = [102432]
+        message = {
+            "jobid": 1,
+            "requestid": 1,
+            "ministryrequestid": 520,
+            "category": "responsepackage",
+            "requestnumber": "EDU-2023-04040757",
+            "bcgovcode": "EDU",
+            "createdby": "foiedu@idir",
+            "filestozip": [],
+            "finaloutput": {},
+            "attributes": json.dumps([{
+                "divisionname": "Learning and Education Programs",
+                "divisionid": 3,
+                "files": [{"s3uripath": "https://example/bucket/responsepackage/source.pdf", "filename": "source.pdf"}],
+            }]),
+            "summarydocuments": json.dumps({
+                "sorteddocuments": [102432],
+                "pkgdocuments": [{"divisionid": 3, "documentids": [102432]}],
+            }),
+            "redactionlayerid": 1,
+            "requesttype": "general",
+            "feeoverridereason": None,
+            "phase": None,
+            "documentsetid": None,
+        }
+
+        service = self.module.redactionsummaryservice()
+        service.processmessage(json.dumps(message))
+
+        self.assertEqual(1, self.fake_utils.doc_connection_count)
+        self.assertEqual(1, self.fake_utils.foi_connection_count)
+        self.assertTrue(self.fake_utils.doc_connection.closed)
+        self.assertTrue(self.fake_utils.foi_connection.closed)
+        self.assertIs(self.documentpageflag.last_pageflags_conn, self.fake_utils.doc_connection)
+        self.assertIs(self.documentpageflag.last_programareas_conn, self.fake_utils.foi_connection)
+        self.assertIs(self.redactionsummary.last_doc_conn, self.fake_utils.doc_connection)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR reduces redaction summary generation overhead by improving batching and reusing scoped database connections throughout the redaction summary workflow.

Changes
Extended batched annotation section lookup to standard redaction summary generation, including non-MCF response packages.

Added batched annotation section resolution using exact (documentid, pagenumber) pairs.

Collected all section page lookups during summary mapping and resolved them through a single getsections_batch() call.

Updated the batch query to use annotationtype = 'freetext', avoiding the slower legacy LIKE '%freetext%' lookup path.

Optimized MCF personal response-package summary generation to assign full-page sections once per summary instead of once per record/document loop.

Added optional caller-owned conn parameters to summary-related documentpageflag DAL methods.

Preserved existing DAL behavior when no connection is provided, with methods continuing to manage their own connections.

Threaded a shared DocumentServices DB connection through redactionsummary.prepareredactionsummary() and related helper calls.

Updated redactionsummaryservice.processmessage() to reuse a single DocumentServices connection and a single FOI connection per message, closing both in a finally block.

Expanded regression and unit test coverage for:

Non-MCF batch section lookup flow
Connection ownership and reuse behavior
Batch SQL generation and section assignment
MCF one-time section assignment
DTS connection propagation
Service-level scoped connection reuse