### PR TITLE
Fix: [FOIMOD-4549] redline package annotation fetch failures

### DIFF
--- a/web/src/apiManager/services/docReviewerService.test.tsx
+++ b/web/src/apiManager/services/docReviewerService.test.tsx
@@ -1,0 +1,85 @@
+import { fetchDocumentAnnotations } from "./docReviewerService";
+import { httpGETBigRequest } from "../httpRequestHandler";
+
+jest.mock("../httpRequestHandler", () => ({
+  httpGETRequest: jest.fn(),
+  httpGETBigRequest: jest.fn(),
+  httpPOSTRequest: jest.fn(),
+  httpGETRequestSOLR: jest.fn(),
+}));
+
+jest.mock("../../services/UserService", () => ({
+  __esModule: true,
+  default: {
+    getToken: jest.fn(() => "token-123"),
+  },
+  getToken: jest.fn(() => "token-123"),
+}));
+
+jest.mock("../../services/StoreService", () => ({
+  store: {
+    dispatch: jest.fn(),
+  },
+}));
+
+jest.mock("../endpoints", () => ({
+  __esModule: true,
+  default: {
+    DOCREVIEWER_ANNOTATION: "http://docreviewer/api/annotation",
+  },
+}));
+
+const mockedHttpGETBigRequest = httpGETBigRequest as jest.MockedFunction<typeof httpGETBigRequest>;
+
+describe("fetchDocumentAnnotations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const userServiceModule = require("../../services/UserService");
+    userServiceModule.default.getToken.mockReturnValue("token-123");
+    userServiceModule.getToken.mockReturnValue("token-123");
+  });
+
+  it("passes the configured timeout to httpGETBigRequest", async () => {
+    mockedHttpGETBigRequest.mockResolvedValueOnce({ data: { 42: ["<redact />"] } } as any);
+    const callback = jest.fn();
+    const errorCallback = jest.fn();
+
+    fetchDocumentAnnotations(51081, "redline", 42, callback, errorCallback, 900000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockedHttpGETBigRequest).toHaveBeenCalledWith(
+      "http://docreviewer/api/annotation/51081/redline/document/42",
+      {},
+      "token-123",
+      900000
+    );
+    expect(callback).toHaveBeenCalledWith({ 42: ["<redact />"] });
+    expect(errorCallback).not.toHaveBeenCalled();
+  });
+
+  it("calls errorCallback with structured details when the annotation request fails", async () => {
+    const requestError = {
+      response: {
+        status: 504,
+        data: { message: "Gateway Timeout" },
+      },
+    };
+    mockedHttpGETBigRequest.mockRejectedValueOnce(requestError);
+    const callback = jest.fn();
+    const errorCallback = jest.fn();
+
+    fetchDocumentAnnotations(51081, "redline", 42, callback, errorCallback, 900000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(errorCallback).toHaveBeenCalledWith({
+      message: "Error in fetching annotations for a document",
+      url: "http://docreviewer/api/annotation/51081/redline/document/42",
+      status: 504,
+      response: { message: "Gateway Timeout" },
+      error: requestError,
+    });
+  });
+});

--- a/web/src/apiManager/services/docReviewerService.tsx
+++ b/web/src/apiManager/services/docReviewerService.tsx
@@ -126,7 +126,13 @@ export const fetchDocumentAnnotations = (
       }
     })
     .catch((error: any) => {
-      errorCallback("Error in fetching annotations for a document");
+      errorCallback({
+        message: "Error in fetching annotations for a document",
+        url: apiUrlGet,
+        status: error?.response?.status,
+        response: error?.response?.data,
+        error,
+      });
     });
 };
 export const fetchAnnotationsInfo = (

--- a/web/src/components/FOI/Home/CreateResponsePDF/annotationFetchQueue.js
+++ b/web/src/components/FOI/Home/CreateResponsePDF/annotationFetchQueue.js
@@ -10,15 +10,23 @@ export const runWithConcurrencyLimit = async (tasks, limit) => {
   const concurrency = Math.max(1, Math.min(limit || 1, tasks.length));
   const results = new Array(tasks.length);
   let nextIndex = 0;
+  let firstError;
 
   const worker = async () => {
-    while (nextIndex < tasks.length) {
+    while (!firstError) {
       const currentIndex = nextIndex;
+      if (currentIndex >= tasks.length) return;
       nextIndex += 1;
-      results[currentIndex] = await tasks[currentIndex]();
+
+      try {
+        results[currentIndex] = await tasks[currentIndex]();
+      } catch (err) {
+        firstError = err;
+        throw err;
+      }
     }
   };
 
-  await Promise.all(Array.from({ length: concurrency }, worker));
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
   return results;
 };

--- a/web/src/components/FOI/Home/CreateResponsePDF/annotationFetchQueue.js
+++ b/web/src/components/FOI/Home/CreateResponsePDF/annotationFetchQueue.js
@@ -1,0 +1,24 @@
+export const runWithConcurrencyLimit = async (tasks, limit) => {
+  if (!Array.isArray(tasks)) {
+    throw new TypeError("tasks must be an array");
+  }
+
+  if (tasks.length === 0) {
+    return [];
+  }
+
+  const concurrency = Math.max(1, Math.min(limit || 1, tasks.length));
+  const results = new Array(tasks.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < tasks.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await tasks[currentIndex]();
+    }
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  return results;
+};

--- a/web/src/components/FOI/Home/CreateResponsePDF/annotationFetchQueue.test.js
+++ b/web/src/components/FOI/Home/CreateResponsePDF/annotationFetchQueue.test.js
@@ -1,0 +1,59 @@
+import { runWithConcurrencyLimit } from "./annotationFetchQueue";
+
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("runWithConcurrencyLimit", () => {
+  it("does not run more than the configured number of tasks at once", async () => {
+    const first = deferred();
+    const second = deferred();
+    const third = deferred();
+    const started = [];
+
+    const tasks = [
+      () => {
+        started.push("first");
+        return first.promise;
+      },
+      () => {
+        started.push("second");
+        return second.promise;
+      },
+      () => {
+        started.push("third");
+        return third.promise;
+      },
+    ];
+
+    const resultPromise = runWithConcurrencyLimit(tasks, 2);
+
+    await Promise.resolve();
+    expect(started).toEqual(["first", "second"]);
+
+    first.resolve("a");
+    await Promise.resolve();
+    expect(started).toEqual(["first", "second", "third"]);
+
+    second.resolve("b");
+    third.resolve("c");
+
+    await expect(resultPromise).resolves.toEqual(["a", "b", "c"]);
+  });
+
+  it("rejects when a task fails", async () => {
+    const tasks = [
+      () => Promise.resolve("a"),
+      () => Promise.reject(new Error("annotation fetch failed")),
+      () => Promise.resolve("c"),
+    ];
+
+    await expect(runWithConcurrencyLimit(tasks, 2)).rejects.toThrow("annotation fetch failed");
+  });
+});

--- a/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js
+++ b/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js
@@ -1019,13 +1019,22 @@ const useSaveRedlineForSignoff = (initDocInstance, initDocViewer, redlinePhase) 
     let documentRedlineAnnotations = {};
     let docCounter = 0;
     for (let documentid of documentids) {
-      fetchDocumentAnnotations(requestid, layer, documentid, async (data) => {
-        docCounter++;
-        documentRedlineAnnotations[documentid] = data[documentid];
-        if (docCounter === documentids.length) {
-          setRedlineDocumentAnnotations(documentRedlineAnnotations);
-        }
-      }, BIG_HTTP_GET_TIMEOUT);
+      fetchDocumentAnnotations(
+        requestid,
+        layer,
+        documentid,
+        async (data) => {
+          docCounter++;
+          documentRedlineAnnotations[documentid] = data[documentid];
+          if (docCounter === documentids.length) {
+            setRedlineDocumentAnnotations(documentRedlineAnnotations);
+          }
+        },
+        (error) => {
+          console.error("Error fetching document annotations:", error);
+        },
+        BIG_HTTP_GET_TIMEOUT
+      );
     }
   };
   const getzipredlinecategory = (layertype) => {

--- a/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js
+++ b/web/src/components/FOI/Home/CreateResponsePDF/useSaveRedlineForSignOff.js
@@ -23,6 +23,7 @@ import { pageFlagTypes, RequestStates } from "../../../../constants/enum";
 import { useParams, useLocation } from "react-router-dom";
 import XMLParser from "react-xml-parser";
 import { BIG_HTTP_GET_TIMEOUT } from "../../../../constants/constants";
+import { runWithConcurrencyLimit } from "./annotationFetchQueue";
 
 const useSaveRedlineForSignoff = (initDocInstance, initDocViewer, redlinePhase) => {
   const currentLayer = useAppSelector((state) => state.documents?.currentLayer);
@@ -1016,25 +1017,47 @@ const useSaveRedlineForSignoff = (initDocInstance, initDocViewer, redlinePhase) 
     documentids,
     layer
   ) => {
-    let documentRedlineAnnotations = {};
-    let docCounter = 0;
-    for (let documentid of documentids) {
-      fetchDocumentAnnotations(
-        requestid,
-        layer,
-        documentid,
-        async (data) => {
-          docCounter++;
-          documentRedlineAnnotations[documentid] = data[documentid];
-          if (docCounter === documentids.length) {
-            setRedlineDocumentAnnotations(documentRedlineAnnotations);
-          }
-        },
-        (error) => {
-          console.error("Error fetching document annotations:", error);
-        },
-        BIG_HTTP_GET_TIMEOUT
-      );
+    const documentRedlineAnnotations = {};
+    const annotationFetchConcurrency = 5;
+
+    const fetchTasks = documentids.map((documentid) => {
+      return () =>
+        new Promise((resolve, reject) => {
+          fetchDocumentAnnotations(
+            requestid,
+            layer,
+            documentid,
+            async (data) => {
+              documentRedlineAnnotations[documentid] = data[documentid] || [];
+              resolve();
+            },
+            (error) => {
+              console.error("Error fetching document annotations:", error);
+              reject(error);
+            },
+            BIG_HTTP_GET_TIMEOUT
+          );
+        });
+    });
+
+    try {
+      await runWithConcurrencyLimit(fetchTasks, annotationFetchConcurrency);
+      setRedlineDocumentAnnotations(documentRedlineAnnotations);
+      return true;
+    } catch (error) {
+      toast.update(toastId.current, {
+        render: "Error fetching annotations for package generation",
+        type: "error",
+        className: "file-upload-toast",
+        isLoading: false,
+        autoClose: 5000,
+        hideProgressBar: true,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        closeButton: true,
+      });
+      return false;
     }
   };
   const getzipredlinecategory = (layertype) => {
@@ -1343,8 +1366,15 @@ const useSaveRedlineForSignoff = (initDocInstance, initDocViewer, redlinePhase) 
         );
         let IncompatableList = prepareRedlineIncompatibleMapping(res);
         setIncompatableList(IncompatableList);
-        fetchDocumentRedlineAnnotations(foiministryrequestid, documentids, currentLayer.name.toLowerCase());
-        
+        const annotationsFetched = await fetchDocumentRedlineAnnotations(
+          foiministryrequestid,
+          documentids,
+          currentLayer.name.toLowerCase()
+        );
+        if (!annotationsFetched) {
+          return;
+        }
+
         let stitchDocuments = {};
         let documentsObjArr = [];
         let divisionstitchpages = [];


### PR DESCRIPTION
  - Fixed fetchDocumentAnnotations callers so the timeout is passed after a real error callback, preventing TypeError: a is not a function.
  - Added structured annotation fetch error details with URL, status, backend response, and original error.
  - Added a concurrency-limited annotation fetch queue for redline/consult package generation. Previously, large packages could start one annotation API request per document all at once, which could overload the browser/backend and lead to timeouts, gateway errors, or a stuck package-generation
    flow. The new queue fetches annotations in controlled batches of 5 and surfaces failures through the package-generation error path.

  - Added targeted Jest coverage for service error handling and queue behavior.