### PR TITLE
TEST CI: add test CI build comments to multiple Dockerfiles

### DIFF
--- a/MCS.FOI.S3FileConversion/Dockerfile
+++ b/MCS.FOI.S3FileConversion/Dockerfile
@@ -75,3 +75,5 @@ RUN apt-get update && \
 COPY --from=build-env /app/MCS.FOI.S3FileConversion/out ./
 RUN chmod a+rwx -R /app
 ENTRYPOINT ["dotnet", "MCS.FOI.S3FileConversion.dll"]
+
+#TEST CI BUILD

--- a/api/dockerfile
+++ b/api/dockerfile
@@ -22,3 +22,5 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 RUN chmod u+x /app/entrypoint.sh
 ENTRYPOINT ["/bin/sh", "/app/entrypoint.sh"]
+
+#TEST CI BUILD

--- a/computingservices/DocumentServices/DockerFile.bcgov
+++ b/computingservices/DocumentServices/DockerFile.bcgov
@@ -17,3 +17,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 USER app_user
 COPY . .
 ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]
+
+#TEST CI BUILD

--- a/computingservices/PDFStitchServices/Dockerfile.local
+++ b/computingservices/PDFStitchServices/Dockerfile.local
@@ -16,3 +16,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 USER app_user
 COPY . .
 ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]
+
+#TEST CI BUILD

--- a/computingservices/ZippingServices/Dockerfile.local
+++ b/computingservices/ZippingServices/Dockerfile.local
@@ -16,3 +16,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 USER app_user
 COPY . .
 ENTRYPOINT ["/bin/sh", "./entrypoint.sh"]
+
+#TEST CI BUILD


### PR DESCRIPTION
This is to test the ci build for the services present in the service catalog at the moment.