### PR TITLE
fix: update selector path to correctly reference resource labels in p…

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -59,7 +59,7 @@ jobs:
                 | .value
                 | to_entries
                 | map(
-                    select(.value.metadata.labels.releaseLabel == env(RELEASE_LABEL))
+                    select(.value.labels.releaseLabel == env(RELEASE_LABEL))
                     | {
                         "kind": $kind,
                         "name": .key,


### PR DESCRIPTION
…rod-release workflow

<!-- Describe the changes in this pull request. -->

---

> **This section is required only for pull requests targeting the `main` branch.**

## Release Label

<!--
Enter the release label exactly as it should be applied to the deployed services.

Examples:
25.4-rc
25.4.1-rc
-->

Release Label: <YOUR-RELEASE-LABEL>