### PR TITLE
chore: remove redundant git pull command from production release work…

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -151,7 +151,6 @@ jobs:
           git config user.email "manish.sihag@gov.bc.ca"
           git config user.name "ManishSihag"
           
-          git pull --rebase origin main
           git add "$VALUES_FILE"
 
           if git diff --cached --quiet; then


### PR DESCRIPTION
…flow

<!-- Describe the changes in this pull request. -->

---

> **This section is required only for pull requests targeting the `main` branch.**

## Release Label

<!--
Enter the release label exactly as it should be applied to the deployed services.

Examples:
25.4-rc
25.4.1-rc
-->

Release Label: <YOUR-RELEASE-LABEL>