### PR TITLE
FOIMOD-5199: Improve Compression Service logging and Redis consumer configuration

### DIFF
--- a/computingservices/CompressionServices/internal/app/app.go
+++ b/computingservices/CompressionServices/internal/app/app.go
@@ -159,6 +159,7 @@ func newApplication(ctx context.Context, command string, cfg config.Config, logg
 		Workload:            cfg.Workload,
 		ProcessingTimeout:   cfg.ProcessingTimeout,
 		FinalizationTimeout: finalizationTimeout,
+		Logger:              logger,
 	})
 
 	if cfg.Mode == config.ModeStandard {

--- a/computingservices/CompressionServices/internal/compression/handler.go
+++ b/computingservices/CompressionServices/internal/compression/handler.go
@@ -300,7 +300,7 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery, start ti
 	)
 }
 
-// logCompleted emits compression_skipped or compression_completed followed by message_completed.
+// logCompleted emits completion events for successful terminal states only.
 func (h *Handler) logCompleted(status string, message models.CompressionProducerMessage, start time.Time) {
 	switch status {
 	case store.StatusSkipped:
@@ -313,6 +313,8 @@ func (h *Handler) logCompleted(status string, message models.CompressionProducer
 			"job_id", message.JobID,
 			"filename", message.Filename,
 		)
+	default:
+		return
 	}
 	h.logger.Info("message_completed",
 		"job_id", message.JobID,

--- a/computingservices/CompressionServices/internal/compression/handler.go
+++ b/computingservices/CompressionServices/internal/compression/handler.go
@@ -3,6 +3,7 @@ package compression
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"reflect"
 	"time"
 
@@ -24,6 +25,7 @@ type Handler struct {
 	processor  Processor
 	followUp   FollowUp
 	options    Options
+	logger     *slog.Logger
 }
 
 func NewHandler(
@@ -35,15 +37,22 @@ func NewHandler(
 	if options.Now == nil {
 		options.Now = time.Now
 	}
+	logger := options.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Handler{
 		repository: repository,
 		processor:  processor,
 		followUp:   followUp,
 		options:    options,
+		logger:     logger,
 	}
 }
 
 func (h *Handler) Process(ctx context.Context, delivery Delivery) (err error) {
+	start := time.Now()
+
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			err = NewRetryableFailure(
@@ -68,19 +77,29 @@ func (h *Handler) Process(ctx context.Context, delivery Delivery) (err error) {
 		return NewRetryableFailure(store.FailureCodeInvalidMessage, errInvalidHandler)
 	}
 
+	h.logger.Info("message_received",
+		"job_id", delivery.Message.JobID,
+		"request_number", delivery.Message.RequestNumber,
+		"filename", delivery.Message.Filename,
+		"document_master_id", delivery.Message.DocumentMasterID,
+		"ministry_request_id", delivery.Message.MinistryRequestID,
+		"workload", string(h.options.Workload),
+	)
+
 	callbackInvoked := false
 	acquired, lockErr := h.repository.WithinJobLock(
 		ctx,
 		delivery.Message.JobID,
 		func(lockCtx context.Context) error {
 			callbackInvoked = true
-			return h.processLocked(lockCtx, delivery)
+			return h.processLocked(lockCtx, delivery, start)
 		},
 	)
 	if lockErr != nil {
 		return retryFrom(lockErr, store.FailureCodeDatabaseUnavailable)
 	}
 	if !acquired {
+		h.logger.Debug("lock_contended", "job_id", delivery.Message.JobID)
 		return NewRetryableFailure(store.FailureCodeDatabaseUnavailable, errLockContended)
 	}
 	if !callbackInvoked {
@@ -92,7 +111,7 @@ func (h *Handler) Process(ctx context.Context, delivery Delivery) (err error) {
 	return nil
 }
 
-func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
+func (h *Handler) processLocked(ctx context.Context, delivery Delivery, start time.Time) error {
 	latest, found, err := h.repository.Latest(ctx, delivery.Message.JobID)
 	if err != nil {
 		return NewRetryableFailure(store.FailureCodeDatabaseUnavailable, err)
@@ -105,9 +124,14 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 			)
 		}
 		h.afterConfirmedTerminal(ctx, delivery.Message, terminalResult(latest.Status))
+		h.logCompleted(latest.Status, delivery.Message, start)
 		return nil
 	}
 	if !preStartWorkloadMatches(h.options.Workload, delivery.Workload, latest, found) {
+		h.logger.Warn("workload_mismatch",
+			"job_id", delivery.Message.JobID,
+			"failure_code", string(store.FailureCodeWorkloadMismatch),
+		)
 		return h.persistFailure(
 			ctx,
 			delivery,
@@ -127,6 +151,10 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 		return NewRetryableFailure(store.FailureCodeDatabaseUnavailable, errTerminalStateUnconfirmed)
 	}
 	if !startedWorkloadMatches(h.options.Workload, delivery.Workload, started) {
+		h.logger.Warn("workload_mismatch",
+			"job_id", delivery.Message.JobID,
+			"failure_code", string(store.FailureCodeWorkloadMismatch),
+		)
 		return h.persistFailure(
 			ctx,
 			delivery,
@@ -135,12 +163,22 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 		)
 	}
 
+	h.logger.Info("compression_started",
+		"job_id", delivery.Message.JobID,
+		"filename", delivery.Message.Filename,
+		"workload", string(h.options.Workload),
+	)
+
 	deadline := started.CreatedAt.Add(h.options.ProcessingTimeout)
 	interruption, interruptionErr := h.classifyInterruption(ctx, nil, deadline)
 	switch interruption {
 	case interruptionCaller:
 		return retryFrom(interruptionErr, store.FailureCodeDatabaseUnavailable)
 	case interruptionJobDeadline:
+		h.logger.Warn("compression_timeout",
+			"job_id", delivery.Message.JobID,
+			"failure_code", string(store.FailureCodeCompressionTimeout),
+		)
 		return h.persistFailure(
 			ctx,
 			delivery,
@@ -154,6 +192,10 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 
 	result, processingErr, processingPanic := h.compress(processingCtx, delivery.Message)
 	if processingPanic != nil {
+		h.logger.Error("compression_failed",
+			"job_id", delivery.Message.JobID,
+			"failure_code", string(store.FailureCodeCompressionPanic),
+		)
 		return h.persistFailure(
 			ctx,
 			delivery,
@@ -163,6 +205,10 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 	}
 	interruption, interruptionErr = h.classifyInterruption(ctx, processingCtx, deadline)
 	if interruption == interruptionJobDeadline {
+		h.logger.Warn("compression_timeout",
+			"job_id", delivery.Message.JobID,
+			"failure_code", string(store.FailureCodeCompressionTimeout),
+		)
 		return h.persistFailure(
 			ctx,
 			delivery,
@@ -178,6 +224,10 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 	}
 	if processingErr != nil {
 		if failure, ok := asFailure(processingErr); ok && !failure.Retryable {
+			h.logger.Error("compression_failed",
+				"job_id", delivery.Message.JobID,
+				"failure_code", string(failure.Code),
+			)
 			return h.persistFailure(
 				ctx,
 				delivery,
@@ -185,9 +235,21 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 				processingErr,
 			)
 		}
-		return retryFrom(processingErr, store.FailureCodeDatabaseUnavailable)
+		resolvedCode := store.FailureCodeDatabaseUnavailable
+		if failure, ok := asFailure(processingErr); ok && failure.Retryable {
+			resolvedCode = store.FailureCode(failure.Error())
+		}
+		h.logger.Warn("compression_failed",
+			"job_id", delivery.Message.JobID,
+			"failure_code", string(resolvedCode),
+		)
+		return NewRetryableFailure(resolvedCode, processingErr)
 	}
 	if result.Status != store.StatusCompleted && result.Status != store.StatusSkipped {
+		h.logger.Error("compression_failed",
+			"job_id", delivery.Message.JobID,
+			"failure_code", string(store.FailureCodeInvalidMessage),
+		)
 		return h.persistFailure(
 			ctx,
 			delivery,
@@ -204,6 +266,7 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 				confirmedResult = terminalResult(stored.Status)
 			}
 			h.afterConfirmedTerminal(ctx, delivery.Message, confirmedResult)
+			h.logCompleted(stored.Status, delivery.Message, start)
 		}
 		return nil
 	}
@@ -214,6 +277,10 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 		if contextInterrupted {
 			interruption, interruptionErr = h.classifyInterruption(ctx, processingCtx, deadline)
 			if interruption == interruptionJobDeadline {
+				h.logger.Warn("compression_timeout",
+					"job_id", delivery.Message.JobID,
+					"failure_code", string(store.FailureCodeCompressionTimeout),
+				)
 				return h.persistFailure(
 					ctx,
 					delivery,
@@ -230,6 +297,27 @@ func (h *Handler) processLocked(ctx context.Context, delivery Delivery) error {
 	return NewRetryableFailure(
 		store.FailureCodeTerminalStatePersistFailed,
 		errTerminalStateUnconfirmed,
+	)
+}
+
+// logCompleted emits compression_skipped or compression_completed followed by message_completed.
+func (h *Handler) logCompleted(status string, message models.CompressionProducerMessage, start time.Time) {
+	switch status {
+	case store.StatusSkipped:
+		h.logger.Info("compression_skipped",
+			"job_id", message.JobID,
+			"filename", message.Filename,
+		)
+	case store.StatusCompleted:
+		h.logger.Info("compression_completed",
+			"job_id", message.JobID,
+			"filename", message.Filename,
+		)
+	}
+	h.logger.Info("message_completed",
+		"job_id", message.JobID,
+		"filename", message.Filename,
+		"duration_ms", time.Since(start).Milliseconds(),
 	)
 }
 
@@ -322,6 +410,7 @@ func (h *Handler) afterConfirmedTerminal(
 		_ = recover()
 	}()
 	h.followUp.AfterTerminal(ctx, message, result)
+	h.logger.Info("ocr_published", "job_id", message.JobID)
 }
 
 func retryFrom(err error, fallback store.FailureCode) error {

--- a/computingservices/CompressionServices/internal/compression/handler_test.go
+++ b/computingservices/CompressionServices/internal/compression/handler_test.go
@@ -1399,6 +1399,39 @@ func TestHandlerLogsCompressionSkipped(t *testing.T) {
 	assert.True(t, ok, "compression_skipped not logged; got: %s", buf.String())
 }
 
+func TestHandlerDoesNotLogMessageCompletedForExistingErrorTerminalState(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	repo.latest = terminalJob(store.StatusError)
+	logger, buf := loggerAndBuffer()
+
+	err := newHandlerWithLogger(repo, &fakeProcessor{}, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	require.NoError(t, err)
+	lines := logLines(buf)
+	_, ok := findEvent(lines, "message_completed")
+	assert.False(t, ok, "message_completed should not be logged for StatusError; got: %s", buf.String())
+}
+
+func TestHandlerDoesNotLogMessageCompletedForCompletionConflictWinnerError(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	repo.completeJob = terminalJob(store.StatusError)
+	processor := &fakeProcessor{result: completedResult()}
+	logger, buf := loggerAndBuffer()
+
+	err := newHandlerWithLogger(repo, processor, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	require.NoError(t, err)
+	lines := logLines(buf)
+	_, ok := findEvent(lines, "message_completed")
+	assert.False(t, ok, "message_completed should not be logged for StatusError; got: %s", buf.String())
+}
+
 func TestHandlerLogsDeterministicFailureAtError(t *testing.T) {
 	t.Parallel()
 	repo := newFakeRepository()

--- a/computingservices/CompressionServices/internal/compression/handler_test.go
+++ b/computingservices/CompressionServices/internal/compression/handler_test.go
@@ -1,8 +1,11 @@
 package compression
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -15,6 +18,71 @@ import (
 )
 
 var fixedNow = time.Now().UTC().Truncate(time.Second)
+
+func loggerAndBuffer() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return logger, &buf
+}
+
+func logLines(buf *bytes.Buffer) []map[string]any {
+	var lines []map[string]any
+	for _, raw := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		if len(raw) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err == nil {
+			lines = append(lines, m)
+		}
+	}
+	return lines
+}
+
+func findEvent(lines []map[string]any, key string) (map[string]any, bool) {
+	for _, l := range lines {
+		if l["msg"] == key {
+			return l, true
+		}
+	}
+	return nil, false
+}
+
+func TestHandlerLogsMessageReceived(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	repo.latest = terminalJob(store.StatusCompleted)
+	logger, buf := loggerAndBuffer()
+
+	_ = newHandlerWithLogger(repo, &fakeProcessor{}, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	lines := logLines(buf)
+	evt, ok := findEvent(lines, "message_received")
+	require.True(t, ok, "message_received not logged; got: %s", buf.String())
+	assert.Equal(t, float64(41), evt["job_id"])
+	assert.NotEmpty(t, evt["filename"])
+	assert.NotContains(t, buf.String(), "s3")
+	assert.NotContains(t, buf.String(), "token")
+}
+
+func TestHandlerLogsLockContendedAtDebug(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	repo.contended = true
+	logger, buf := loggerAndBuffer()
+
+	_ = newHandlerWithLogger(repo, &fakeProcessor{}, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	lines := logLines(buf)
+	evt, ok := findEvent(lines, "lock_contended")
+	require.True(t, ok, "lock_contended not logged; got: %s", buf.String())
+	assert.Equal(t, "DEBUG", evt["level"])
+	assert.Equal(t, float64(41), evt["job_id"])
+}
 
 func TestProcessExistingTerminalStatesShortCircuit(t *testing.T) {
 	tests := []struct {
@@ -1223,6 +1291,16 @@ func newTestHandler(repo Repository, processor Processor, followUp FollowUp) *Ha
 	})
 }
 
+func newHandlerWithLogger(repo *fakeRepository, processor Processor, followUp FollowUp, logger *slog.Logger) *Handler {
+	return NewHandler(repo, processor, followUp, Options{
+		Workload:            config.WorkloadNormal,
+		ProcessingTimeout:   15 * time.Minute,
+		FinalizationTimeout: 10 * time.Second,
+		Now:                 func() time.Time { return fixedNow },
+		Logger:              logger,
+	})
+}
+
 func delivery(jobID int) Delivery {
 	return Delivery{
 		EventID:       "event-1",
@@ -1230,7 +1308,11 @@ func delivery(jobID int) Delivery {
 		StreamID:      "stream-1",
 		Workload:      config.WorkloadNormal,
 		Message: models.CompressionProducerMessage{
-			JobID: jobID,
+			JobID:             jobID,
+			Filename:          "test-document.pdf",
+			RequestNumber:     "req-123",
+			DocumentMasterID:  999,
+			MinistryRequestID: 888,
 		},
 	}
 }
@@ -1264,4 +1346,143 @@ func completedResult() store.CompressionResult {
 		CompressedSize: 1234,
 		Extension:      ".pdf",
 	}
+}
+
+func TestHandlerLogsCompressionStarted(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	// no latest job — forces EnsureStarted path
+	processor := &fakeProcessor{result: store.CompressionResult{Status: store.StatusCompleted}}
+	logger, buf := loggerAndBuffer()
+
+	err := newHandlerWithLogger(repo, processor, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	require.NoError(t, err)
+	lines := logLines(buf)
+	_, ok := findEvent(lines, "compression_started")
+	assert.True(t, ok, "compression_started not logged; got: %s", buf.String())
+}
+
+func TestHandlerLogsCompressionCompleted(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	processor := &fakeProcessor{result: store.CompressionResult{Status: store.StatusCompleted}}
+	logger, buf := loggerAndBuffer()
+
+	err := newHandlerWithLogger(repo, processor, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	require.NoError(t, err)
+	lines := logLines(buf)
+	_, ok := findEvent(lines, "compression_completed")
+	assert.True(t, ok, "compression_completed not logged; got: %s", buf.String())
+	_, ok2 := findEvent(lines, "message_completed")
+	assert.True(t, ok2, "message_completed not logged; got: %s", buf.String())
+}
+
+func TestHandlerLogsCompressionSkipped(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	processor := &fakeProcessor{result: store.CompressionResult{Status: store.StatusSkipped}}
+	logger, buf := loggerAndBuffer()
+
+	err := newHandlerWithLogger(repo, processor, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	require.NoError(t, err)
+	lines := logLines(buf)
+	_, ok := findEvent(lines, "compression_skipped")
+	assert.True(t, ok, "compression_skipped not logged; got: %s", buf.String())
+}
+
+func TestHandlerLogsDeterministicFailureAtError(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	processor := &fakeProcessor{err: NewDeterministicFailure(store.FailureCodeUnsupportedDocument, errors.New("bad doc"))}
+	logger, buf := loggerAndBuffer()
+
+	_ = newHandlerWithLogger(repo, processor, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	lines := logLines(buf)
+	evt, ok := findEvent(lines, "compression_failed")
+	require.True(t, ok, "compression_failed not logged; got: %s", buf.String())
+	assert.Equal(t, "ERROR", evt["level"])
+	assert.Equal(t, string(store.FailureCodeUnsupportedDocument), evt["failure_code"])
+	assert.NotContains(t, buf.String(), "bad doc")
+}
+
+func TestHandlerLogsRetryableFailureAtWarn(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	processor := &fakeProcessor{err: NewRetryableFailure(store.FailureCodeDatabaseUnavailable, errors.New("db down"))}
+	logger, buf := loggerAndBuffer()
+
+	_ = newHandlerWithLogger(repo, processor, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	lines := logLines(buf)
+	evt, ok := findEvent(lines, "compression_failed")
+	require.True(t, ok, "compression_failed not logged; got: %s", buf.String())
+	assert.Equal(t, "WARN", evt["level"])
+	assert.NotContains(t, buf.String(), "db down")
+}
+
+func TestHandlerLogsInvalidProcessorResultAsError(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	processor := &fakeProcessor{result: store.CompressionResult{Status: "unknown"}}
+	logger, buf := loggerAndBuffer()
+
+	_ = newHandlerWithLogger(repo, processor, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	lines := logLines(buf)
+	evt, ok := findEvent(lines, "compression_failed")
+	require.True(t, ok, "compression_failed not logged; got: %s", buf.String())
+	assert.Equal(t, "ERROR", evt["level"])
+	assert.Equal(t, string(store.FailureCodeInvalidMessage), evt["failure_code"])
+}
+
+func TestMessageCompletedContainsDurationMs(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	processor := &fakeProcessor{result: store.CompressionResult{Status: store.StatusCompleted}}
+	logger, buf := loggerAndBuffer()
+
+	err := newHandlerWithLogger(repo, processor, &fakeFollowUp{}, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	require.NoError(t, err)
+	lines := logLines(buf)
+	evt, ok := findEvent(lines, "message_completed")
+	require.True(t, ok)
+	dms, hasDur := evt["duration_ms"]
+	assert.True(t, hasDur, "duration_ms missing from message_completed")
+	assert.GreaterOrEqual(t, dms.(float64), float64(0))
+}
+
+func TestHandlerLogsOCRPublished(t *testing.T) {
+	t.Parallel()
+	repo := newFakeRepository()
+	processor := &fakeProcessor{result: store.CompressionResult{Status: store.StatusCompleted}}
+	followUp := &fakeFollowUp{}
+	logger, buf := loggerAndBuffer()
+
+	err := newHandlerWithLogger(repo, processor, followUp, logger).Process(
+		context.Background(), delivery(41),
+	)
+
+	require.NoError(t, err)
+	lines := logLines(buf)
+	_, ok := findEvent(lines, "ocr_published")
+	assert.True(t, ok, "ocr_published not logged; got: %s", buf.String())
 }

--- a/computingservices/CompressionServices/internal/compression/types.go
+++ b/computingservices/CompressionServices/internal/compression/types.go
@@ -3,6 +3,7 @@ package compression
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"compressionservices/internal/config"
@@ -49,4 +50,5 @@ type Options struct {
 	ProcessingTimeout   time.Duration
 	FinalizationTimeout time.Duration
 	Now                 func() time.Time
+	Logger              *slog.Logger
 }

--- a/computingservices/CompressionServices/internal/config/config.go
+++ b/computingservices/CompressionServices/internal/config/config.go
@@ -30,6 +30,7 @@ type Messaging struct {
 	StreamPrefix        string
 	Topic               string
 	ConsumerGroup       string
+	ConsumerName        string
 	LegacyStreamKey     string
 	LegacyCheckpointKey string
 	ClaimInterval       time.Duration
@@ -201,6 +202,7 @@ func Load(getenv func(string) string) (Config, error) {
 	messaging := Messaging{
 		RedisAddress:        net.JoinHostPort(redisHost, strconv.Itoa(redisPort)),
 		RedisPassword:       getenv("REDIS_PASSWORD"),
+		ConsumerName:        strings.TrimSpace(getenv("REDIS_CONSUMER_NAME")),
 		ClaimInterval:       claimInterval,
 		ClaimMinIdle:        claimMinIdle,
 		MaxDeliveryAttempts: maxDeliveryAttempts,

--- a/computingservices/CompressionServices/internal/config/config_test.go
+++ b/computingservices/CompressionServices/internal/config/config_test.go
@@ -351,3 +351,13 @@ func TestLoadErrorsDoNotExposeSecretValues(t *testing.T) {
 	assert.False(t, strings.Contains(err.Error(), "redis-secret"))
 	assert.False(t, strings.Contains(err.Error(), "database-secret"))
 }
+
+func TestLoadReadsOptionalRedisConsumerName(t *testing.T) {
+	env := standardNormalEnv()
+	env["REDIS_CONSUMER_NAME"] = " compression-normal-pod-123 "
+
+	got, err := Load(func(key string) string { return env[key] })
+
+	require.NoError(t, err)
+	assert.Equal(t, "compression-normal-pod-123", got.Messaging.ConsumerName)
+}

--- a/computingservices/CompressionServices/internal/consumer/standard.go
+++ b/computingservices/CompressionServices/internal/consumer/standard.go
@@ -132,6 +132,7 @@ func standardMessagingConfig(cfg config.Config, logger *slog.Logger) messaging.C
 		},
 		Consumer: messaging.ConsumerConfig{
 			Group:               cfg.Messaging.ConsumerGroup,
+			ConsumerName:        cfg.Messaging.ConsumerName,
 			Concurrency:         1,
 			ClaimInterval:       cfg.Messaging.ClaimInterval,
 			ClaimMinIdle:        cfg.Messaging.ClaimMinIdle,

--- a/computingservices/CompressionServices/internal/consumer/standard_test.go
+++ b/computingservices/CompressionServices/internal/consumer/standard_test.go
@@ -180,6 +180,7 @@ func TestStandard_RegistersConfiguredContractBeforeRun(t *testing.T) {
 
 func TestStandardMessagingConfig_MapsProductionSettings(t *testing.T) {
 	cfg := validStandardConfig()
+	cfg.Messaging.ConsumerName = "reviewer-compression-marshal-7f5f7c9bd8-h9k2m"
 	logger := testLogger()
 
 	got := standardMessagingConfig(cfg, logger)
@@ -192,6 +193,7 @@ func TestStandardMessagingConfig_MapsProductionSettings(t *testing.T) {
 	}, got.Redis)
 	assert.Equal(t, messaging.ConsumerConfig{
 		Group:               cfg.Messaging.ConsumerGroup,
+		ConsumerName:        cfg.Messaging.ConsumerName,
 		Concurrency:         1,
 		ClaimInterval:       cfg.Messaging.ClaimInterval,
 		ClaimMinIdle:        cfg.Messaging.ClaimMinIdle,

--- a/computingservices/CompressionServices/main.go
+++ b/computingservices/CompressionServices/main.go
@@ -5,18 +5,33 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"compressionservices/internal/app"
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	level := logLevelFromEnv(os.Getenv("LOG_LEVEL"))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	if err := app.Run(ctx, os.Args[1:], os.Getenv, logger); err != nil {
 		logStopped(logger, err)
 		os.Exit(1)
+	}
+}
+
+func logLevelFromEnv(value string) slog.Level {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "WARN", "WARNING":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
 	}
 }
 

--- a/openshift/templates/compression/compression-deploy.yaml
+++ b/openshift/templates/compression/compression-deploy.yaml
@@ -72,6 +72,10 @@ objects:
                 secretKeyRef:
                   name: "${SECRETS}"
                   key: COMPRESSION_REDIS_PORT
+            - name: REDIS_CONSUMER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: COMPRESSION_STREAM_KEY
               valueFrom:
                 secretKeyRef:

--- a/openshift/templates/compression/compression-largefiles-deploy.yaml
+++ b/openshift/templates/compression/compression-largefiles-deploy.yaml
@@ -88,6 +88,10 @@ objects:
                 secretKeyRef:
                   name: "${SECRETS}"
                   key: REDIS_PORT
+            - name: REDIS_CONSUMER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: COMPRESSION_STREAM_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Adds structured logging to the Compression Service to improve traceability and make it easier to follow documents through the compression flow.

### Changes

- Add structured logging for key compression processing milestones
- Log completion, skipped, timeout, retryable, and failure scenarios
- Add document/job metadata for easier troubleshooting
- Add processing duration metrics
- Log OCR publication after successful compression
- Wire the application logger into the compression handler
- Add configurable `LOG_LEVEL` with `INFO` as the default
- Configure pod-based Redis consumer identity for OpenShift workers
- Add test coverage for the new logging events